### PR TITLE
#105: setTypoStyle text 기본값 설정 로직 변경

### DIFF
--- a/POME/global/Resource/DesignSystem/TypoStyle.swift
+++ b/POME/global/Resource/DesignSystem/TypoStyle.swift
@@ -125,7 +125,9 @@ extension UILabel {
     
     func setTypoStyleWithSingleLine(typoStyle: TypoStyle) {
         
-        self.text = " "
+        if(self.text == nil){
+            self.text = " "
+        }
         
         let font = typoStyle.font
         let kernValue = typoStyle.labelDescription.kern
@@ -145,7 +147,9 @@ extension UILabel {
     
     func setTypoStyleWithMultiLine(typoStyle: TypoStyle) {
         
-        self.text = " "
+        if(self.text == nil){
+            self.text = " "
+        }
         
         let font = typoStyle.font
         let kernValue = typoStyle.labelDescription.kern
@@ -175,7 +179,9 @@ extension UITextView{
     
     func setTypoStyleWithMultiLine(typoStyle: TypoStyle) {
         
-        self.text = " "
+        if(self.text == nil){
+            self.text = " "
+        }
         
         let font = typoStyle.font
         let kernValue = typoStyle.labelDescription.kern


### PR DESCRIPTION
## What is this PR? 🔍
#105: setTypoStyle text 기본값 설정 로직 변경

## Key Changes 🔑
1. setTypoStyle 메서드 내 기본값 처리 로직 변경
   - 기존에 text = " "로 전부 기본값 처리해버려서 text를 typoStyle 보다 먼저 처리한 경우 UI 상 text가 나타나지 않게 되는 버그가 존재했는데, 따로 UI 수정안하고 오류 해결되도록 메서드 코드 수정했습니다!

## To Reviewers 📢
- 풀 받고 써주세요오
