### PR TITLE
Refactor/#114 BaseViewController disposeBag 프로퍼티, bind 추상 메서드 선언

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,3 +6,6 @@
 
 ## To Reviewers 📢
 - 리뷰어들에게 할 말
+
+
+## Related Issues ⛱

--- a/POME/Domain/UseCases/Goal/CreateGoalUseCase.swift
+++ b/POME/Domain/UseCases/Goal/CreateGoalUseCase.swift
@@ -13,10 +13,10 @@ protocol CreateGoalUseCase{
 
 class DefaultCreateGoalUseCase: CreateGoalUseCase{
     
-    private let goalRepository: DefaultGoalRepository
+    private let repository: DefaultGoalRepository
     
-    init(goalRepository: DefaultGoalRepository){
-        self.goalRepository = goalRepository
+    init(repository: DefaultGoalRepository){
+        self.repository = repository
     }
     
     func createGoal() {

--- a/POME/Domain/ViewModels/Goal/GoalDateRegisterViewModel.swift
+++ b/POME/Domain/ViewModels/Goal/GoalDateRegisterViewModel.swift
@@ -6,17 +6,21 @@
 //
 
 import Foundation
+import RxSwift
+import RxCocoa
 
 class GoalDateRegisterViewModel{
     
     private let goalUseCase: CreateGoalUseCase
     
     struct Input{
-        
+        let startDateTextField: Observable<String>
+        let endDateTextField: Observable<String>
+        let completeButtonControlEvent: ControlEvent<Void>
     }
     
     struct Output{
-        
+        let canMoveNext: Driver<Bool>
     }
     
     init(goalUseCase: CreateGoalUseCase){
@@ -24,6 +28,14 @@ class GoalDateRegisterViewModel{
     }
     
     func transform(input: Input) -> Output{
-        return Output()
+        
+        let requestObservable = Observable.combineLatest(input.startDateTextField, input.endDateTextField)
+        
+        let canMoveNext = requestObservable
+            .map { startDate, endDate in
+                return !startDate.isEmpty && !endDate.isEmpty
+            }.asDriver(onErrorJustReturn: false)
+
+        return Output(canMoveNext: canMoveNext)
     }
 }

--- a/POME/Global/Source/Base/BaseViewController.swift
+++ b/POME/Global/Source/Base/BaseViewController.swift
@@ -8,10 +8,12 @@
 import UIKit
 import SnapKit
 import Then
+import RxSwift
 
 class BaseViewController: UIViewController {
     
     let navigationView = UIView()
+    let disposeBag = DisposeBag()
 
     lazy var backBtn = UIButton().then{
         $0.setImage(Image.backArrow, for: .normal)
@@ -35,6 +37,7 @@ class BaseViewController: UIViewController {
         style()
         layout()
         initialize()
+        bind()
     }
     
     /* BaseViewController method
@@ -69,6 +72,8 @@ class BaseViewController: UIViewController {
     }
     
     func initialize() {}
+    
+    func bind() { }
     
     @objc func backBtnDidClicked(){
         self.navigationController?.popViewController(animated: true)

--- a/POME/Presentation/Utils/Goal/GoalRequestManager.swift
+++ b/POME/Presentation/Utils/Goal/GoalRequestManager.swift
@@ -12,5 +12,8 @@ class GoalRequestManager{
     
     static let shared = GoalRequestManager()
     
+    var startDate: String = ""
+    var endDate: String = ""
+    
     private init() { }
 }

--- a/POME/Presentation/ViewControllers/Register/AddFriend/FriendSearchViewController.swift
+++ b/POME/Presentation/ViewControllers/Register/AddFriend/FriendSearchViewController.swift
@@ -12,8 +12,6 @@ import RxCocoa
 class FriendSearchViewController: BaseViewController {
     var friendSearchView: FriendSearchView!
     var name = BehaviorRelay(value: "")
-
-    let disposeBag = DisposeBag()
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/POME/Presentation/ViewControllers/Register/Register/AppRegisterViewController.swift
+++ b/POME/Presentation/ViewControllers/Register/Register/AppRegisterViewController.swift
@@ -18,8 +18,6 @@ class AppRegisterViewController: BaseViewController {
     var isValidName = false
     var isValidPhone = false
     var isValidCode = false
-    
-    let disposeBag = DisposeBag()
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/POME/Resource/Storyboard/SSOOYA.storyboard
+++ b/POME/Resource/Storyboard/SSOOYA.storyboard
@@ -9,10 +9,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Record Register Content View Controller-->
+        <!--Goal Date View Controller-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController modalPresentationStyle="overFullScreen" id="Y6W-OH-hqX" customClass="RecordRegisterContentViewController" customModule="POME" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController modalPresentationStyle="overFullScreen" id="Y6W-OH-hqX" customClass="GoalDateViewController" customModule="POME" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>


### PR DESCRIPTION
## What is this PR? 🔍
 BaseViewController disposeBag 프로퍼티, bind 추상 메서드 선언

## Key Changes 🔑
1. disposeBag 프로퍼티 선언
   - RxSwift 본격 사용 위한 BaseViewController 프로퍼티 추가
   - 각 ViewController마다 선언할 필요 없이 disposeBag 이름으로 접근 가능
   - 기존 disposeBag 선언되어있던 ViewController에서 해당 프로퍼티 제거
2. bind 추상 메서드 선언
   - MVVM 패턴으로 리팩토링 위한 메서드 추가
   - bind 메서드 통해 ViewModel과 View/ViewController 연결하면 됩니다 
3. GoalDateRegisterViewModel 구현
   - 내일(1/9) 회의 시간에 예시로 작성한 GoalRegister 쪽 설계 보면서 같이 Clean Architecture & MVVM 적용에 대해서 이야기 해보면 좋을 것 같습니다아~ 화이팅
4. 풀리퀘 템플릿 관련 이슈 필드 추가
   
## To Reviewers 📢
- 공통 소스 부분 수정된 부분 있으니 풀 받고 사용해주세요~

