### PR TITLE
Refactor/#121: ImagePopUpVC completion 구현, 생성자 레이블 생성, show 메서드 추가

### DIFF
--- a/POME.xcodeproj/project.pbxproj
+++ b/POME.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		57397FBC296E77DE0088B5F4 /* CreateRecordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57397FBB296E77DE0088B5F4 /* CreateRecordUseCase.swift */; };
 		57397FBF296E78200088B5F4 /* RecordRegisterRequestManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57397FBE296E78200088B5F4 /* RecordRegisterRequestManager.swift */; };
 		5741BA3E294B3AF700ABDDE5 /* RegisterSuccessType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5741BA3D294B3AF700ABDDE5 /* RegisterSuccessType.swift */; };
+		574E616029718ADE002BCDAF /* AlertInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574E615F29718ADE002BCDAF /* AlertInfo.swift */; };
 		57543B782951BF0200A409E3 /* CalendarSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57543B772951BF0200A409E3 /* CalendarSheetViewController.swift */; };
 		57543B7A2951BF3700A409E3 /* CalendarSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57543B792951BF3700A409E3 /* CalendarSheetView.swift */; };
 		57543B7C2951BF5300A409E3 /* CalendarSheetCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57543B7B2951BF5300A409E3 /* CalendarSheetCollectionViewCell.swift */; };
@@ -291,6 +292,7 @@
 		57397FBB296E77DE0088B5F4 /* CreateRecordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateRecordUseCase.swift; sourceTree = "<group>"; };
 		57397FBE296E78200088B5F4 /* RecordRegisterRequestManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordRegisterRequestManager.swift; sourceTree = "<group>"; };
 		5741BA3D294B3AF700ABDDE5 /* RegisterSuccessType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterSuccessType.swift; sourceTree = "<group>"; };
+		574E615F29718ADE002BCDAF /* AlertInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertInfo.swift; sourceTree = "<group>"; };
 		57543B772951BF0200A409E3 /* CalendarSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSheetViewController.swift; sourceTree = "<group>"; };
 		57543B792951BF3700A409E3 /* CalendarSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSheetView.swift; sourceTree = "<group>"; };
 		57543B7B2951BF5300A409E3 /* CalendarSheetCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarSheetCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -439,6 +441,7 @@
 		2367FC5A292BEC53006ED970 /* PopUp */ = {
 			isa = PBXGroup;
 			children = (
+				574E615F29718ADE002BCDAF /* AlertInfo.swift */,
 				2367FC5B292BECB8006ED970 /* ImagePopUpViewController.swift */,
 				235B3972292D6288003ACA01 /* TextPopUpViewController.swift */,
 			);
@@ -1576,6 +1579,7 @@
 				23B3B7DC29319411008CB960 /* SecondEmotionViewController.swift in Sources */,
 				23A17C51292BC93100426825 /* RecordCardTableViewCell.swift in Sources */,
 				5724EC722918CFBA00DC529B /* BaseCollectionViewCell.swift in Sources */,
+				574E616029718ADE002BCDAF /* AlertInfo.swift in Sources */,
 				2306123C292B4CB500662007 /* OnboardingViewController.swift in Sources */,
 				23858E5C292B6E6B00707572 /* TermsView.swift in Sources */,
 				57CCA795292B2D76007E22D1 /* ConsumeReviewTableViewCell.swift in Sources */,

--- a/POME/Domain/ViewModels/Goal/GoalContentRegisterViewModel.swift
+++ b/POME/Domain/ViewModels/Goal/GoalContentRegisterViewModel.swift
@@ -41,3 +41,4 @@ class GoalContentRegisterViewModel{
         return Output(canMoveNext: canMoveNext)
     }
 }
+

--- a/POME/Domain/ViewModels/Record/Register/RecordRegisterEmotionSelectViewModel.swift
+++ b/POME/Domain/ViewModels/Record/Register/RecordRegisterEmotionSelectViewModel.swift
@@ -8,17 +8,21 @@
 import Foundation
 import RxSwift
 import RxCocoa
+import RxGesture
 
 class RecordRegisterEmotionSelectViewModel{
     
     private let createRecorUseCase: CreateRecordUseCase
     
     struct Input{
-//        let emotionSelect: Observable<>
+        let happyEmotionSelect: TapObservable
+        let whatEmotionSelect: TapObservable
+        let sadEmotionSelect: TapObservable
+        let completeButtonActiveStatus: ControlEvent<Void>
     }
     
     struct Output{
-        let canMoveNext: ControlEvent<Void>
+        let canMoveNext: Driver<Bool>
     }
     
     init(createRecordUseCase: CreateRecordUseCase){
@@ -26,9 +30,12 @@ class RecordRegisterEmotionSelectViewModel{
     }
     
 //    func transform(input: Input) -> Output{
-        
-//        let canMoveNext
-        
+//
+//        //TODO: 이모지 하나 tap 했을 때, 버튼 활성화 시키기
+//        let canMoveNext = input.happyEmotionSelect
+//            .map{
+//
+//            }
 //        return Output(canMoveNext: canMoveNext)
 //    }
     

--- a/POME/Domain/ViewModels/Record/Register/RecordRegisterEmotionSelectViewModel.swift
+++ b/POME/Domain/ViewModels/Record/Register/RecordRegisterEmotionSelectViewModel.swift
@@ -6,4 +6,31 @@
 //
 
 import Foundation
+import RxSwift
+import RxCocoa
 
+class RecordRegisterEmotionSelectViewModel{
+    
+    private let createRecorUseCase: CreateRecordUseCase
+    
+    struct Input{
+//        let emotionSelect: Observable<>
+    }
+    
+    struct Output{
+        let canMoveNext: ControlEvent<Void>
+    }
+    
+    init(createRecordUseCase: CreateRecordUseCase){
+        self.createRecorUseCase = createRecordUseCase
+    }
+    
+//    func transform(input: Input) -> Output{
+        
+//        let canMoveNext
+        
+//        return Output(canMoveNext: canMoveNext)
+//    }
+    
+    
+}

--- a/POME/Global/Source/Base/BaseViewController.swift
+++ b/POME/Global/Source/Base/BaseViewController.swift
@@ -48,8 +48,9 @@ class BaseViewController: UIViewController {
     */
     
     func style() {
-        self.navigationController?.navigationBar.isHidden = true
         self.view.backgroundColor = .white
+        self.navigationController?.navigationBar.isHidden = true
+        self.tabBarController?.tabBar.isHidden = true
     }
     
     func layout() {

--- a/POME/Global/Source/Calendar/CalendarSheetViewController.swift
+++ b/POME/Global/Source/Calendar/CalendarSheetViewController.swift
@@ -31,10 +31,11 @@ class CalendarSheetViewController: BaseSheetViewController {
     
     //MARK: - Properties
     
+    var possibleDateRange: (CalendarSelectDate, CalendarSelectDate)!
     var selectDate: CalendarSelectDate!
     var completion: ((CalendarSelectDate) -> ())!
     
-    private var calendar = Calendar.current
+    var calendar = Calendar.current
     
     private var calendarDate: Date!{
         didSet{
@@ -188,5 +189,26 @@ extension CalendarSheetViewController: UICollectionViewDelegate, UICollectionVie
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         guard let cell = collectionView.cellForItem(at: indexPath) as? CalendarSheetCollectionViewCell else { return }
         cell.changeViewAttributesByState(.normal)
+    }
+}
+
+class EndDateCalendarSheetViewController: CalendarSheetViewController{
+    
+    private let startDate: String!
+    private var possibleEndDate: CalendarSelectDate!
+    
+    init(with startDate: String?){
+        self.startDate = startDate
+        super.init()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func caculatePossibleDuration(){
+//        let calendar = Calendar
+        let start = PomeDateFormatter.getDateType(from: startDate)
+//        let endDate = calendar.date(byAdding: .date, value: 30, to: start)
     }
 }

--- a/POME/Global/Source/PopUp/AlertInfo.swift
+++ b/POME/Global/Source/PopUp/AlertInfo.swift
@@ -1,0 +1,12 @@
+//
+//  AlertInfo.swift
+//  POME
+//
+//  Created by 박지윤 on 2023/01/13.
+//
+
+import Foundation
+
+enum AlertInfo{
+    
+}

--- a/POME/Global/Source/PopUp/ImagePopUpViewController.swift
+++ b/POME/Global/Source/PopUp/ImagePopUpViewController.swift
@@ -37,11 +37,11 @@ class ImagePopUpViewController: UIViewController {
     var cancelBtn: UIButton!
     var okBtn: UIButton!
     // MARK: - Life Cycles
-    convenience init(_ imageValue: UIImage? = nil,
-                     _ titleText: String? = nil,
-                     _ messageText: String? = nil,
-                     _ greenBtnText: String? = nil,
-                     _ grayBtnText: String? = nil) {
+    convenience init(imageValue: UIImage? = nil,
+                     titleText: String? = nil,
+                     messageText: String? = nil,
+                     greenBtnText: String? = nil,
+                     grayBtnText: String? = nil) {
         self.init()
 
         self.imageValue = imageValue

--- a/POME/Global/Source/PopUp/ImagePopUpViewController.swift
+++ b/POME/Global/Source/PopUp/ImagePopUpViewController.swift
@@ -51,11 +51,16 @@ class ImagePopUpViewController: UIViewController {
         self.messageText = messageText
         self.greenBtnText = greenBtnText
         self.grayBtnText = grayBtnText
-        
-        setUpContent()
-        setUpView()
-        setUpConstraint()
     }
+    
+    func show(in viewController: UIViewController) -> ImagePopUpViewController{
+        self.modalPresentationStyle = .overFullScreen
+        viewController.present(self, animated: false, completion: nil)
+        return self
+    }
+    
+    //MARK: - Override
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = Color.popUpBackground

--- a/POME/Global/Source/PopUp/ImagePopUpViewController.swift
+++ b/POME/Global/Source/PopUp/ImagePopUpViewController.swift
@@ -10,6 +10,8 @@ import UIKit
 // Default 팝업창
 class ImagePopUpViewController: UIViewController {
     // MARK: - Properties
+    var completion: (() -> ())!
+    
     private var imageValue: UIImage?
     private var titleText: String?
     private var messageText: String?
@@ -57,8 +59,13 @@ class ImagePopUpViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = Color.popUpBackground
-
+        
+        setUpContent()
+        setUpView()
+        setUpConstraint()
+        
         cancelBtn.addTarget(self, action: #selector(goBack), for: .touchUpInside)
+        okBtn.addTarget(self, action: #selector(completeButtonDidCicked), for: .touchUpInside)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -79,12 +86,16 @@ class ImagePopUpViewController: UIViewController {
             self?.popupView.isHidden = true
         }
     }
+    
     // MARK: - Actions
     @objc func goBack() {
         self.dismiss(animated: false)
     }
+    @objc func completeButtonDidCicked(){
+        self.dismiss(animated: false, completion: self.completion)
+    }
     // MARK: - Functions
-    func setUpContent() {
+    private func setUpContent() {
         popupImage.image = self.imageValue
         titleLabel.text = self.titleText
         titleLabel.setTypoStyleWithSingleLine(typoStyle: .title3)
@@ -97,7 +108,7 @@ class ImagePopUpViewController: UIViewController {
         cancelBtn = DefaultButton(titleStr: self.grayBtnText ?? "", typo: .title3, backgroundColor: Color.grey1, titleColor: Color.grey5)
         okBtn = DefaultButton(titleStr: self.greenBtnText ?? "")
     }
-    func setUpView() {
+    private func setUpView() {
         self.view.addSubview(popupView)
         
         popupView.addSubview(popupImage)
@@ -106,7 +117,7 @@ class ImagePopUpViewController: UIViewController {
         popupView.addSubview(cancelBtn)
         popupView.addSubview(okBtn)
     }
-    func setUpConstraint() {
+    private func setUpConstraint() {
         popupView.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview().inset(24)
             make.height.greaterThanOrEqualTo(148)

--- a/POME/Global/Source/PopUp/TextPopUpViewController.swift
+++ b/POME/Global/Source/PopUp/TextPopUpViewController.swift
@@ -27,9 +27,9 @@ class TextPopUpViewController: UIViewController {
     var cancelBtn: UIButton!
     var okBtn: UIButton!
     // MARK: - Life Cycles
-    convenience init(_ titleText: String? = nil,
-                     _ greenBtnText: String? = nil,
-                     _ grayBtnText: String? = nil) {
+    convenience init(titleText: String? = nil,
+                     greenBtnText: String? = nil,
+                     grayBtnText: String? = nil) {
         self.init()
 
         self.titleText = titleText

--- a/POME/Presentation/Cells/Review/ConsumeReviewTableViewCell.swift
+++ b/POME/Presentation/Cells/Review/ConsumeReviewTableViewCell.swift
@@ -20,18 +20,9 @@ class ConsumeReviewTableViewCell: BaseTableViewCell {
     let mainView = ReviewDetailView().then{
         $0.memoLabel.numberOfLines = 2
     }
-
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
     
     override func setting(){
         super.setting()
-        
         self.selectedBackgroundView = UIView()
     }
     

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -184,10 +184,6 @@ extension FriendViewController: UICollectionViewDelegate, UICollectionViewDataSo
             return CGSize(width: EmojiFloatingCollectionViewCell.cellWidth, height: EmojiFloatingCollectionViewCell.cellWidth)
         }
     }
-    
-    
-    
-    
 }
 
 //MARK: - TableView Delegate

--- a/POME/Presentation/ViewControllers/Goal/GoalContentViewController.swift
+++ b/POME/Presentation/ViewControllers/Goal/GoalContentViewController.swift
@@ -79,10 +79,11 @@ class GoalContentViewController: BaseViewController {
         let dialog = ImagePopUpViewController(imageValue: Image.penMint,
                                               titleText: "작성을 그만 두시겠어요?",
                                               messageText: "지금까지 작성한 내용은 모두 사라져요",
-                                              greenBtnText: "이어서 쓸래요",
-                                              grayBtnText: "그만 둘래요")
-        dialog.modalPresentationStyle = .overFullScreen
-        self.present(dialog, animated: false, completion: nil)
+                                              greenBtnText: "그만 둘래요",
+                                              grayBtnText: "이어서 쓸래요").show(in: self)
+        dialog.completion = {
+            self.navigationController?.popToRootViewController(animated: true)
+        }
     }
     
     private func completeButtonDidClicked(){

--- a/POME/Presentation/ViewControllers/Goal/GoalContentViewController.swift
+++ b/POME/Presentation/ViewControllers/Goal/GoalContentViewController.swift
@@ -76,11 +76,11 @@ class GoalContentViewController: BaseViewController {
     //MARK: - Helper
     
     private func closeButtonDidClicked(){
-        let dialog = ImagePopUpViewController(Image.penMint,
-                                              "작성을 그만 두시겠어요?",
-                                              "지금까지 작성한 내용은 모두 사라져요",
-                                              "이어서 쓸래요",
-                                              "그만 둘래요")
+        let dialog = ImagePopUpViewController(imageValue: Image.penMint,
+                                              titleText: "작성을 그만 두시겠어요?",
+                                              messageText: "지금까지 작성한 내용은 모두 사라져요",
+                                              greenBtnText: "이어서 쓸래요",
+                                              grayBtnText: "그만 둘래요")
         dialog.modalPresentationStyle = .overFullScreen
         self.present(dialog, animated: false, completion: nil)
     }

--- a/POME/Presentation/ViewControllers/Goal/GoalContentViewController.swift
+++ b/POME/Presentation/ViewControllers/Goal/GoalContentViewController.swift
@@ -25,7 +25,6 @@ class GoalContentViewController: BaseViewController {
         super.layout()
         
         self.view.addSubview(mainView)
-        
         mainView.snp.makeConstraints{
             $0.top.equalToSuperview().offset(Offset.VIEW_CONTROLLER_TOP)
             $0.leading.trailing.equalToSuperview()
@@ -38,10 +37,6 @@ class GoalContentViewController: BaseViewController {
         super.initialize()
         
         self.view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(keyboardWillDisappear)))
-        
-        etcButton.addTarget(self, action: #selector(backBtnDidClicked), for: .touchUpInside)
-        mainView.goalMakePublicSwitch.addTarget(self, action: #selector(publicSwitchBackgroundColorWillChange), for: .valueChanged)
-        mainView.completeButton.addTarget(self, action: #selector(completeButtonDidClicked), for: .touchUpInside)
         
         mainView.categoryField.infoTextField.delegate = self
         mainView.promiseField.infoTextField.delegate = self
@@ -59,9 +54,28 @@ class GoalContentViewController: BaseViewController {
         output.canMoveNext
             .drive(mainView.completeButton.rx.isActivate)
             .disposed(by: disposeBag)
+        
+        mainView.completeButton.rx.tap
+            .bind{
+                self.completeButtonDidClicked()
+            }.disposed(by: disposeBag)
+        
+        mainView.goalMakePublicSwitch.rx.isOn
+            .asDriver(onErrorJustReturn: false)
+            .drive(onNext: { value in
+                self.mainView.changeGoalMakePublicViewStatus(with: value)
+            })
+            .disposed(by: disposeBag)
+        
+        etcButton.rx.tap
+            .bind{
+                self.closeButtonDidClicked()
+            }.disposed(by: disposeBag)
     }
     
-    override func backBtnDidClicked() {
+    //MARK: - Helper
+    
+    private func closeButtonDidClicked(){
         let dialog = ImagePopUpViewController(Image.penMint,
                                               "작성을 그만 두시겠어요?",
                                               "지금까지 작성한 내용은 모두 사라져요",
@@ -71,13 +85,7 @@ class GoalContentViewController: BaseViewController {
         self.present(dialog, animated: false, completion: nil)
     }
     
-    //MARK: - Action
-    
-    @objc func publicSwitchBackgroundColorWillChange(_ sender: UISwitch){
-        mainView.goalMakePublicView.backgroundColor = sender.isOn ? Color.pink10 : Color.grey1
-    }
-    
-    @objc func completeButtonDidClicked(){
+    private func completeButtonDidClicked(){
         let vc = RegisterSuccessViewController(type: .goal)
         self.navigationController?.pushViewController(vc, animated: true)
     }
@@ -86,6 +94,8 @@ class GoalContentViewController: BaseViewController {
         self.view.endEditing(true)
     }
 }
+
+//MARK: - UITextFieldDelegate
 
 extension GoalContentViewController: UITextFieldDelegate{
     

--- a/POME/Presentation/ViewControllers/Goal/GoalDateViewController.swift
+++ b/POME/Presentation/ViewControllers/Goal/GoalDateViewController.swift
@@ -12,6 +12,8 @@ import RxGesture
 
 class GoalDateViewController: BaseViewController {
     
+    private var startDate: String!
+    
     private let mainView = GoalDateView()
     private let viewModel = GoalDateRegisterViewModel(goalUseCase: DefaultCreateGoalUseCase(repository: DefaultGoalRepository()))
 
@@ -77,9 +79,19 @@ class GoalDateViewController: BaseViewController {
         
         guard let dateField = sender.view as? CommonRightButtonTextFieldView else { return }
         
+        /*
         let sheet = CalendarSheetViewController().loadAndShowBottomSheet(in: self)
+        */
+        
+        let sheet: CalendarSheetViewController = sender == mainView.startDateField ? CalendarSheetViewController() : EndDateCalendarSheetViewController(with: startDate)
+        
+        _ = sheet.loadAndShowBottomSheet(in: self)
         sheet.completion = { date in
-            dateField.infoTextField.text = PomeDateFormatter.getDateString(date)
+            let dateString = PomeDateFormatter.getDateString(date)
+            if(sheet == self.mainView.startDateField){
+                self.startDate = dateString
+            }
+            dateField.infoTextField.text = dateString
             dateField.infoTextField.sendActions(for: .valueChanged)
         }
     }

--- a/POME/Presentation/ViewControllers/Goal/GoalDateViewController.swift
+++ b/POME/Presentation/ViewControllers/Goal/GoalDateViewController.swift
@@ -8,18 +8,13 @@
 import UIKit
 import RxSwift
 import RxCocoa
+import RxGesture
 
 class GoalDateViewController: BaseViewController {
     
-    let mainView = GoalDateView()
+    private let mainView = GoalDateView()
     private let viewModel = GoalDateRegisterViewModel(goalUseCase: DefaultCreateGoalUseCase(repository: DefaultGoalRepository()))
-    
-    //MARK: - LifeCycle
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
-    
     //MARK: - Override
     
     override func layout() {
@@ -34,14 +29,6 @@ class GoalDateViewController: BaseViewController {
         }
     }
     
-    override func initialize(){
-        
-        mainView.completButton.addTarget(self, action: #selector(completeButtonDidClicked), for: .touchUpInside)
-
-        mainView.startDateField.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(calendarSheetWillShow)))
-        mainView.endDateField.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(calendarSheetWillShow)))
-    }
-    
     override func bind(){
         let input = GoalDateRegisterViewModel.Input(startDateTextField:
                                                         mainView.startDateField.infoTextField.rx.text.orEmpty.asObservable(),
@@ -54,6 +41,24 @@ class GoalDateViewController: BaseViewController {
         output.canMoveNext
             .drive(mainView.completButton.rx.isActivate)
             .disposed(by: disposeBag)
+        
+        mainView.completButton.rx.tap
+            .bind{
+                self.completeButtonDidClicked()
+            }.disposed(by: disposeBag)
+        
+        mainView.startDateField.rx.tapGesture()
+            .when(.recognized)
+            .bind(onNext: { sender in
+                self.calendarSheetWillShow(sender)
+            }).disposed(by: disposeBag)
+        
+        
+        mainView.endDateField.rx.tapGesture()
+            .when(.recognized)
+            .bind(onNext: { sender in
+                self.calendarSheetWillShow(sender)
+            }).disposed(by: disposeBag)
     }
     
     //MARK: - Action
@@ -68,7 +73,7 @@ class GoalDateViewController: BaseViewController {
         self.present(dialog, animated: false, completion: nil)
     }
     
-    @objc func calendarSheetWillShow(_ sender: UITapGestureRecognizer){
+    private func calendarSheetWillShow(_ sender: UITapGestureRecognizer){
         
         guard let dateField = sender.view as? CommonRightButtonTextFieldView else { return }
         
@@ -79,7 +84,7 @@ class GoalDateViewController: BaseViewController {
         }
     }
     
-    @objc func completeButtonDidClicked(){
+    private func completeButtonDidClicked(){
         let vc = GoalContentViewController()
         self.navigationController?.pushViewController(vc, animated: true)
     }

--- a/POME/Presentation/ViewControllers/Goal/GoalDateViewController.swift
+++ b/POME/Presentation/ViewControllers/Goal/GoalDateViewController.swift
@@ -66,11 +66,11 @@ class GoalDateViewController: BaseViewController {
     //MARK: - Action
     
     override func backBtnDidClicked() {
-        let dialog = ImagePopUpViewController(Image.penMint,
-                                              "작성을 그만 두시겠어요?",
-                                              "지금까지 작성한 내용은 모두 사라져요",
-                                              "이어서 쓸래요",
-                                              "그만 둘래요")
+        let dialog = ImagePopUpViewController(imageValue: Image.penMint,
+                                              titleText: "작성을 그만 두시겠어요?",
+                                              messageText: "지금까지 작성한 내용은 모두 사라져요",
+                                              greenBtnText: "이어서 쓸래요",
+                                              grayBtnText: "그만 둘래요")
         dialog.modalPresentationStyle = .overFullScreen
         self.present(dialog, animated: false, completion: nil)
     }

--- a/POME/Presentation/ViewControllers/Goal/GoalDateViewController.swift
+++ b/POME/Presentation/ViewControllers/Goal/GoalDateViewController.swift
@@ -69,10 +69,11 @@ class GoalDateViewController: BaseViewController {
         let dialog = ImagePopUpViewController(imageValue: Image.penMint,
                                               titleText: "작성을 그만 두시겠어요?",
                                               messageText: "지금까지 작성한 내용은 모두 사라져요",
-                                              greenBtnText: "이어서 쓸래요",
-                                              grayBtnText: "그만 둘래요")
-        dialog.modalPresentationStyle = .overFullScreen
-        self.present(dialog, animated: false, completion: nil)
+                                              greenBtnText: "그만 둘래요",
+                                              grayBtnText: "이어서 쓸래요").show(in: self)
+        dialog.completion = {
+            self.navigationController?.popToRootViewController(animated: true)
+        }
     }
     
     private func calendarSheetWillShow(_ sender: UITapGestureRecognizer){

--- a/POME/Presentation/ViewControllers/MyPage/CompletedGoalsViewController.swift
+++ b/POME/Presentation/ViewControllers/MyPage/CompletedGoalsViewController.swift
@@ -65,7 +65,11 @@ class CompletedGoalsViewController: BaseViewController {
     @objc func menuButtonDidTap() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         let deleteAction =  UIAlertAction(title: "삭제하기", style: UIAlertAction.Style.default){(_) in
-            let dialog = ImagePopUpViewController(Image.trashGreen, "종료된 목표를 삭제할까요?", "지금까지 작성된 기록들은 모두 사라져요", "삭제할게요", "아니요")
+            let dialog = ImagePopUpViewController(imageValue: Image.trashGreen,
+                                                  titleText: "종료된 목표를 삭제할까요?",
+                                                  messageText: "지금까지 작성된 기록들은 모두 사라져요",
+                                                  greenBtnText: "삭제할게요",
+                                                  grayBtnText: "아니요")
             dialog.modalPresentationStyle = .overFullScreen
             self.present(dialog, animated: false, completion: nil)
         }

--- a/POME/Presentation/ViewControllers/MyPage/CompletedGoalsViewController.swift
+++ b/POME/Presentation/ViewControllers/MyPage/CompletedGoalsViewController.swift
@@ -69,9 +69,7 @@ class CompletedGoalsViewController: BaseViewController {
                                                   titleText: "종료된 목표를 삭제할까요?",
                                                   messageText: "지금까지 작성된 기록들은 모두 사라져요",
                                                   greenBtnText: "삭제할게요",
-                                                  grayBtnText: "아니요")
-            dialog.modalPresentationStyle = .overFullScreen
-            self.present(dialog, animated: false, completion: nil)
+                                                  grayBtnText: "아니요").show(in: self)
         }
         let cancelAction = UIAlertAction(title: "취소", style: UIAlertAction.Style.cancel, handler: nil)
         

--- a/POME/Presentation/ViewControllers/MyPage/MypageFriendViewController.swift
+++ b/POME/Presentation/ViewControllers/MyPage/MypageFriendViewController.swift
@@ -53,9 +53,7 @@ class MypageFriendViewController: BaseViewController {
                                               titleText: "친구를 삭제하시겠어요?",
                                               messageText: "친구의 씀씀이를 더 이상 볼 수 없어요",
                                               greenBtnText: "삭제할게요",
-                                              grayBtnText: "아니요")
-        dialog.modalPresentationStyle = .overFullScreen
-        self.present(dialog, animated: false, completion: nil)
+                                              grayBtnText: "아니요").show(in: self)
     }
 }
 // MARK: - TableView delegate

--- a/POME/Presentation/ViewControllers/MyPage/MypageFriendViewController.swift
+++ b/POME/Presentation/ViewControllers/MyPage/MypageFriendViewController.swift
@@ -49,7 +49,11 @@ class MypageFriendViewController: BaseViewController {
         }
     }
     @objc func showDeleteFriendDialog() {
-        let dialog = ImagePopUpViewController(Image.trashPink, "친구를 삭제하시겠어요?", "친구의 씀씀이를 더 이상 볼 수 없어요", "삭제할게요", "아니요")
+        let dialog = ImagePopUpViewController(imageValue: Image.trashPink,
+                                              titleText: "친구를 삭제하시겠어요?",
+                                              messageText: "친구의 씀씀이를 더 이상 볼 수 없어요",
+                                              greenBtnText: "삭제할게요",
+                                              grayBtnText: "아니요")
         dialog.modalPresentationStyle = .overFullScreen
         self.present(dialog, animated: false, completion: nil)
     }

--- a/POME/Presentation/ViewControllers/MyPage/SettingViewController.swift
+++ b/POME/Presentation/ViewControllers/MyPage/SettingViewController.swift
@@ -58,7 +58,7 @@ class SettingViewController: BaseViewController {
         }
     }
     func showLogoutDialog() {
-        let dialog = TextPopUpViewController("로그아웃 하시겠어요?", "네", "아니요")
+        let dialog = TextPopUpViewController(titleText: "로그아웃 하시겠어요?", greenBtnText: "네", grayBtnText: "아니요")
         dialog.modalPresentationStyle = .overFullScreen
         self.present(dialog, animated: false, completion: nil)
         

--- a/POME/Presentation/ViewControllers/Record/FinishGoal/AllRecordsViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/FinishGoal/AllRecordsViewController.swift
@@ -52,7 +52,11 @@ class AllRecordsViewController: BaseViewController {
             print("click modify")
         }
         let deleteAction =  UIAlertAction(title: "삭제하기", style: UIAlertAction.Style.default){(_) in
-            let dialog = ImagePopUpViewController(Image.trashGreen, "기록을 삭제하시겠어요?", "삭제한 내용은 다시 되돌릴 수 없어요", "삭제할게요", "아니요")
+            let dialog = ImagePopUpViewController(imageValue: Image.trashGreen,
+                                                  titleText: "기록을 삭제하시겠어요?",
+                                                  messageText: "삭제한 내용은 다시 되돌릴 수 없어요",
+                                                  greenBtnText: "삭제할게요",
+                                                  grayBtnText: "아니요")
             dialog.modalPresentationStyle = .overFullScreen
             self.present(dialog, animated: false, completion: nil)
         }
@@ -67,7 +71,11 @@ class AllRecordsViewController: BaseViewController {
     @objc func alertGoalMenuButtonDidTap() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         let deleteAction =  UIAlertAction(title: "삭제하기", style: UIAlertAction.Style.default){(_) in
-            let dialog = ImagePopUpViewController(Image.trashGreen, "목표를 삭제하시겠어요?", "해당 목표에서 작성한 기록도 모두 삭제돼요", "삭제할게요", "아니요")
+            let dialog = ImagePopUpViewController(imageValue: Image.trashGreen,
+                                                  titleText: "목표를 삭제하시겠어요?",
+                                                  messageText: "해당 목표에서 작성한 기록도 모두 삭제돼요",
+                                                  greenBtnText: "삭제할게요",
+                                                  grayBtnText: "아니요")
             dialog.modalPresentationStyle = .overFullScreen
             self.present(dialog, animated: false, completion: nil)
         }

--- a/POME/Presentation/ViewControllers/Record/FinishGoal/AllRecordsViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/FinishGoal/AllRecordsViewController.swift
@@ -56,9 +56,7 @@ class AllRecordsViewController: BaseViewController {
                                                   titleText: "기록을 삭제하시겠어요?",
                                                   messageText: "삭제한 내용은 다시 되돌릴 수 없어요",
                                                   greenBtnText: "삭제할게요",
-                                                  grayBtnText: "아니요")
-            dialog.modalPresentationStyle = .overFullScreen
-            self.present(dialog, animated: false, completion: nil)
+                                                  grayBtnText: "아니요").show(in: self)
         }
         let cancelAction = UIAlertAction(title: "취소", style: UIAlertAction.Style.cancel, handler: nil)
         
@@ -75,9 +73,7 @@ class AllRecordsViewController: BaseViewController {
                                                   titleText: "목표를 삭제하시겠어요?",
                                                   messageText: "해당 목표에서 작성한 기록도 모두 삭제돼요",
                                                   greenBtnText: "삭제할게요",
-                                                  grayBtnText: "아니요")
-            dialog.modalPresentationStyle = .overFullScreen
-            self.present(dialog, animated: false, completion: nil)
+                                                  grayBtnText: "아니요").show(in: self)
         }
         let cancelAction = UIAlertAction(title: "취소", style: UIAlertAction.Style.cancel, handler: nil)
         

--- a/POME/Presentation/ViewControllers/Record/FinishGoal/CommentViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/FinishGoal/CommentViewController.swift
@@ -52,9 +52,7 @@ class CommentViewController: BaseViewController {
                                               titleText: "종료된 목표를 삭제할까요?",
                                               messageText: "지금까지 작성된 기록들은 모두 사라져요",
                                               greenBtnText: "삭제할게요",
-                                              grayBtnText: "아니요")
-        dialog.modalPresentationStyle = .overFullScreen
-        self.present(dialog, animated: false, completion: nil)
+                                              grayBtnText: "아니요").show(in: self)
     }
 }
 // MARK: - TextView delegate

--- a/POME/Presentation/ViewControllers/Record/FinishGoal/CommentViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/FinishGoal/CommentViewController.swift
@@ -48,7 +48,11 @@ class CommentViewController: BaseViewController {
         self.navigationController?.pushViewController(SubmitViewController(), animated: true)
     }
     @objc func notSubmitButtonDidTap() {
-        let dialog = ImagePopUpViewController(Image.trashGreen, "종료된 목표를 삭제할까요?", "지금까지 작성된 기록들은 모두 사라져요", "삭제할게요", "아니요")
+        let dialog = ImagePopUpViewController(imageValue: Image.trashGreen,
+                                              titleText: "종료된 목표를 삭제할까요?",
+                                              messageText: "지금까지 작성된 기록들은 모두 사라져요",
+                                              greenBtnText: "삭제할게요",
+                                              grayBtnText: "아니요")
         dialog.modalPresentationStyle = .overFullScreen
         self.present(dialog, animated: false, completion: nil)
     }

--- a/POME/Presentation/ViewControllers/Record/RecordEmotionViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/RecordEmotionViewController.swift
@@ -42,7 +42,11 @@ class RecordEmotionViewController: BaseViewController {
             print("click modify")
         }
         let deleteAction =  UIAlertAction(title: "삭제하기", style: UIAlertAction.Style.default){(_) in
-            let dialog = ImagePopUpViewController(Image.trashGreen, "기록을 삭제하시겠어요?", "삭제한 내용은 다시 되돌릴 수 없어요", "삭제할게요", "아니요")
+            let dialog = ImagePopUpViewController(imageValue: Image.trashGreen,
+                                                  titleText: "기록을 삭제하시겠어요?",
+                                                  messageText: "삭제한 내용은 다시 되돌릴 수 없어요",
+                                                  greenBtnText: "삭제할게요",
+                                                  grayBtnText: "아니요")
             dialog.modalPresentationStyle = .overFullScreen
             self.present(dialog, animated: false, completion: nil)
         }

--- a/POME/Presentation/ViewControllers/Record/RecordEmotionViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/RecordEmotionViewController.swift
@@ -46,9 +46,7 @@ class RecordEmotionViewController: BaseViewController {
                                                   titleText: "기록을 삭제하시겠어요?",
                                                   messageText: "삭제한 내용은 다시 되돌릴 수 없어요",
                                                   greenBtnText: "삭제할게요",
-                                                  grayBtnText: "아니요")
-            dialog.modalPresentationStyle = .overFullScreen
-            self.present(dialog, animated: false, completion: nil)
+                                                  grayBtnText: "아니요").show(in: self)
         }
         let cancelAction = UIAlertAction(title: "취소", style: UIAlertAction.Style.cancel, handler: nil)
         

--- a/POME/Presentation/ViewControllers/Record/RecordViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/RecordViewController.swift
@@ -42,14 +42,18 @@ class RecordViewController: BaseTabViewController {
         self.navigationController?.pushViewController(NotificationViewController(), animated: true)
     }
     @objc func writeButtonDidTap() {
+        //TODO: 소비 기록 등록/소비 등록 제한 코드 분리
+        let vc = RecordRegisterContentViewController()
+        self.navigationController?.pushViewController(vc, animated: true)
+        /*
         let sheet = RecordBottomSheetViewController(Image.flagMint, "지금은 씀씀이를 기록할 수 없어요", "나만의 소비 목표를 설정하고\n기록을 시작해보세요!")
         sheet.loadViewIfNeeded()
         self.present(sheet, animated: true, completion: nil)
+         */
     }
     @objc func cannotAddGoalButtonDidTap() {
-        //목표 추가 vc 이동
+        //TODO: 목표 등록/개수 제한 팝업 코드 분리
         let vc = GoalDateViewController()
-//        self.tabBarController?.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(vc, animated: true)
        
         /*

--- a/POME/Presentation/ViewControllers/Record/RecordViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/RecordViewController.swift
@@ -74,9 +74,7 @@ class RecordViewController: BaseTabViewController {
                                                   titleText: "목표를 삭제하시겠어요?",
                                                   messageText: "해당 목표에서 작성한 기록도 모두 삭제돼요",
                                                   greenBtnText: "삭제할게요",
-                                                  grayBtnText: "아니요")
-            dialog.modalPresentationStyle = .overFullScreen
-            self.present(dialog, animated: false, completion: nil)
+                                                  grayBtnText: "아니요").show(in: self)
         }
         let cancelAction = UIAlertAction(title: "취소", style: UIAlertAction.Style.cancel, handler: nil)
         
@@ -95,9 +93,7 @@ class RecordViewController: BaseTabViewController {
                                                   titleText: "기록을 삭제하시겠어요?",
                                                   messageText: "삭제한 내용은 다시 되돌릴 수 없어요",
                                                   greenBtnText: "삭제할게요",
-                                                  grayBtnText: "아니요")
-            dialog.modalPresentationStyle = .overFullScreen
-            self.present(dialog, animated: false, completion: nil)
+                                                  grayBtnText: "아니요").show(in: self)
         }
         let cancelAction = UIAlertAction(title: "취소", style: UIAlertAction.Style.cancel, handler: nil)
         

--- a/POME/Presentation/ViewControllers/Record/RecordViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/RecordViewController.swift
@@ -47,9 +47,16 @@ class RecordViewController: BaseTabViewController {
         self.present(sheet, animated: true, completion: nil)
     }
     @objc func cannotAddGoalButtonDidTap() {
+        //목표 추가 vc 이동
+        let vc = GoalDateViewController()
+//        self.tabBarController?.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(vc, animated: true)
+       
+        /*
         let sheet = RecordBottomSheetViewController(Image.ten, "목표는 10개를 넘을 수 없어요", "포미는 사용자가 무리하지 않고 즐겁게 목표를\n달성할 수 있도록 응원하고 있어요!")
         sheet.loadViewIfNeeded()
         self.present(sheet, animated: true, completion: nil)
+         */
     }
     func cannotAddEmotionDidTap() {
         let sheet = RecordBottomSheetViewController(Image.penPink, "아직은 감정을 기록할 수 없어요", "일주일이 지나야 감정을 남길 수 있어요\n나중에 다시 봐요!")

--- a/POME/Presentation/ViewControllers/Record/RecordViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/RecordViewController.swift
@@ -70,7 +70,11 @@ class RecordViewController: BaseTabViewController {
     @objc func alertGoalMenuButtonDidTap() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         let deleteAction =  UIAlertAction(title: "삭제하기", style: UIAlertAction.Style.default){(_) in
-            let dialog = ImagePopUpViewController(Image.trashGreen, "목표를 삭제하시겠어요?", "해당 목표에서 작성한 기록도 모두 삭제돼요", "삭제할게요", "아니요")
+            let dialog = ImagePopUpViewController(imageValue: Image.trashGreen,
+                                                  titleText: "목표를 삭제하시겠어요?",
+                                                  messageText: "해당 목표에서 작성한 기록도 모두 삭제돼요",
+                                                  greenBtnText: "삭제할게요",
+                                                  grayBtnText: "아니요")
             dialog.modalPresentationStyle = .overFullScreen
             self.present(dialog, animated: false, completion: nil)
         }
@@ -87,7 +91,11 @@ class RecordViewController: BaseTabViewController {
             print("click modify")
         }
         let deleteAction =  UIAlertAction(title: "삭제하기", style: UIAlertAction.Style.default){(_) in
-            let dialog = ImagePopUpViewController(Image.trashGreen, "기록을 삭제하시겠어요?", "삭제한 내용은 다시 되돌릴 수 없어요", "삭제할게요", "아니요")
+            let dialog = ImagePopUpViewController(imageValue: Image.trashGreen,
+                                                  titleText: "기록을 삭제하시겠어요?",
+                                                  messageText: "삭제한 내용은 다시 되돌릴 수 없어요",
+                                                  greenBtnText: "삭제할게요",
+                                                  grayBtnText: "아니요")
             dialog.modalPresentationStyle = .overFullScreen
             self.present(dialog, animated: false, completion: nil)
         }
@@ -100,7 +108,9 @@ class RecordViewController: BaseTabViewController {
         self.present(alert, animated: true)
     }
     func showGoalFinishWarning() {
-        let sheet = RecordBottomSheetViewController(Image.penPink, "아직 돌아보지 않은 기록이 있어요!", "씀씀이 기록 후 일주일 뒤에\n감정을 돌아보고 목표를 종료할 수 있어요")
+        let sheet = RecordBottomSheetViewController(Image.penPink,
+                                                    "아직 돌아보지 않은 기록이 있어요!",
+                                                    "씀씀이 기록 후 일주일 뒤에\n감정을 돌아보고 목표를 종료할 수 있어요")
         sheet.loadViewIfNeeded()
         self.present(sheet, animated: true, completion: nil)
     }

--- a/POME/Presentation/ViewControllers/Record/Register/RecordRegisterContentViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/RecordRegisterContentViewController.swift
@@ -43,9 +43,6 @@ class RecordRegisterContentViewController: BaseViewController {
         
         mainView.priceField.infoTextField.delegate = self
         mainView.contentTextView.recordTextView.delegate = self
-        
-        mainView.goalField.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(categorySheetWillShow)))
-        mainView.dateField.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(calendarSheetWillShow)))
     }
     
     override func bind(){
@@ -63,10 +60,23 @@ class RecordRegisterContentViewController: BaseViewController {
             .drive(mainView.completeButton.rx.isActivate)
             .disposed(by: disposeBag)
         
+        mainView.goalField.rx.tapGesture()
+            .when(.recognized)
+            .bind{ _ in
+                self.categorySheetWillShow()
+            }
+        
+        mainView.dateField.rx.tapGesture()
+            .when(.recognized)
+            .bind{ _ in
+                self.calendarSheetWillShow()
+            }
+        
         mainView.completeButton.rx.tap
             .bind{
                 self.completeButtonDidClicked()
             }.disposed(by: disposeBag)
+        
     }
     
     //MARK: - Helper
@@ -87,7 +97,7 @@ class RecordRegisterContentViewController: BaseViewController {
         self.view.endEditing(true)
     }
     
-    @objc private func calendarSheetWillShow(){
+    private func calendarSheetWillShow(){
         
         let sheet = CalendarSheetViewController()
         
@@ -102,18 +112,15 @@ class RecordRegisterContentViewController: BaseViewController {
         self.present(sheet, animated: true)
     }
     
-    @objc private func categorySheetWillShow(){
+    private func categorySheetWillShow(){
         
-        let sheet = CategorySelectSheetViewController()
+        let sheet = CategorySelectSheetViewController().loadAndShowBottomSheet(in: self)
         
         sheet.categorySelectHandler = { title in
             self.recordInput.category = title
             self.mainView.goalField.infoTextField.text = title
             self.mainView.goalField.infoTextField.sendActions(for: .valueChanged)
         }
-        
-        sheet.loadViewIfNeeded()
-        self.present(sheet, animated: true)
     }
     
     @objc private func completeButtonDidClicked(){

--- a/POME/Presentation/ViewControllers/Record/Register/RecordRegisterContentViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/RecordRegisterContentViewController.swift
@@ -133,10 +133,11 @@ class RecordRegisterContentViewController: BaseViewController {
         let dialog = ImagePopUpViewController(imageValue: Image.penMint,
                                               titleText: "작성을 그만 두시겠어요?",
                                               messageText: "지금까지 작성한 내용은 모두 사라져요",
-                                              greenBtnText: "이어서 쓸래요",
-                                              grayBtnText: "그만 둘래요")
-        dialog.modalPresentationStyle = .overFullScreen
-        self.present(dialog, animated: false, completion: nil)
+                                              greenBtnText: "그만 둘래요",
+                                              grayBtnText: "이어서 쓸래요").show(in: self)
+        dialog.completion = {
+            self.navigationController?.popToRootViewController(animated: true)
+        }
     }
     
     @objc private func keyboardWillAppear(noti: NSNotification) {

--- a/POME/Presentation/ViewControllers/Record/Register/RecordRegisterContentViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/RecordRegisterContentViewController.swift
@@ -38,9 +38,6 @@ class RecordRegisterContentViewController: BaseViewController {
     }
     
     override func initialize() {
-        
-        self.view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(viewDidTapped)))
-        
         mainView.priceField.infoTextField.delegate = self
         mainView.contentTextView.recordTextView.delegate = self
     }
@@ -60,17 +57,23 @@ class RecordRegisterContentViewController: BaseViewController {
             .drive(mainView.completeButton.rx.isActivate)
             .disposed(by: disposeBag)
         
+        self.view.rx.tapGesture()
+            .when(.recognized)
+            .bind(onNext: { _ in
+                self.view.endEditing(true)
+            }).disposed(by: disposeBag)
+        
         mainView.goalField.rx.tapGesture()
             .when(.recognized)
-            .bind{ _ in
+            .bind(onNext: { _ in
                 self.categorySheetWillShow()
-            }
+            }).disposed(by: disposeBag)
         
         mainView.dateField.rx.tapGesture()
             .when(.recognized)
-            .bind{ _ in
+            .bind(onNext: { _ in
                 self.calendarSheetWillShow()
-            }
+            }).disposed(by: disposeBag)
         
         mainView.completeButton.rx.tap
             .bind{
@@ -93,13 +96,9 @@ class RecordRegisterContentViewController: BaseViewController {
     
     //MARK: - Action
     
-    @objc private func viewDidTapped(){
-        self.view.endEditing(true)
-    }
-    
     private func calendarSheetWillShow(){
         
-        let sheet = CalendarSheetViewController()
+        let sheet = CalendarSheetViewController().loadAndShowBottomSheet(in: self)
         
         sheet.completion = { date in
             self.mainView.dateField.infoTextField.text = PomeDateFormatter.getDateString(date)
@@ -107,9 +106,6 @@ class RecordRegisterContentViewController: BaseViewController {
             
             self.recordInput.consumeDate = PomeDateFormatter.getDateString(date)
         }
-        
-        sheet.loadViewIfNeeded()
-        self.present(sheet, animated: true)
     }
     
     private func categorySheetWillShow(){

--- a/POME/Presentation/ViewControllers/Record/Register/RecordRegisterContentViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/RecordRegisterContentViewController.swift
@@ -130,11 +130,11 @@ class RecordRegisterContentViewController: BaseViewController {
     }
     
     override func backBtnDidClicked(){
-        let dialog = ImagePopUpViewController(Image.penMint,
-                                              "작성을 그만 두시겠어요?",
-                                              "지금까지 작성한 내용은 모두 사라져요",
-                                              "이어서 쓸래요",
-                                              "그만 둘래요")
+        let dialog = ImagePopUpViewController(imageValue: Image.penMint,
+                                              titleText: "작성을 그만 두시겠어요?",
+                                              messageText: "지금까지 작성한 내용은 모두 사라져요",
+                                              greenBtnText: "이어서 쓸래요",
+                                              grayBtnText: "그만 둘래요")
         dialog.modalPresentationStyle = .overFullScreen
         self.present(dialog, animated: false, completion: nil)
     }

--- a/POME/Presentation/ViewControllers/Record/Register/RecordRegisterEmotionSelectViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/RecordRegisterEmotionSelectViewController.swift
@@ -91,11 +91,11 @@ class RecordRegisterEmotionSelectViewController: BaseViewController{
     }
     
     func closeButtonDidClicked(){
-        let dialog = ImagePopUpViewController(Image.penMint,
-                                              "작성을 그만 두시겠어요?",
-                                              "지금까지 작성한 내용은 모두 사라져요",
-                                              "이어서 쓸래요",
-                                              "그만 둘래요")
+        let dialog = ImagePopUpViewController(imageValue: Image.penMint,
+                                              titleText: "작성을 그만 두시겠어요?",
+                                              messageText: "지금까지 작성한 내용은 모두 사라져요",
+                                              greenBtnText: "이어서 쓸래요",
+                                              grayBtnText: "그만 둘래요")
         dialog.modalPresentationStyle = .overFullScreen
         self.present(dialog, animated: false, completion: nil)
     }

--- a/POME/Presentation/ViewControllers/Record/Register/RecordRegisterEmotionSelectViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/RecordRegisterEmotionSelectViewController.swift
@@ -94,10 +94,11 @@ class RecordRegisterEmotionSelectViewController: BaseViewController{
         let dialog = ImagePopUpViewController(imageValue: Image.penMint,
                                               titleText: "작성을 그만 두시겠어요?",
                                               messageText: "지금까지 작성한 내용은 모두 사라져요",
-                                              greenBtnText: "이어서 쓸래요",
-                                              grayBtnText: "그만 둘래요")
-        dialog.modalPresentationStyle = .overFullScreen
-        self.present(dialog, animated: false, completion: nil)
+                                              greenBtnText: "그만 둘래요",
+                                              grayBtnText: "이어서 쓸래요").show(in: self)
+        dialog.completion = {
+            self.navigationController?.popToRootViewController(animated: true)
+        }
     }
     
     private func emotionViewDidClicked(_ sender: UITapGestureRecognizer){

--- a/POME/Presentation/ViewControllers/Record/Register/RecordRegisterEmotionSelectViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/RecordRegisterEmotionSelectViewController.swift
@@ -10,18 +10,15 @@ import SnapKit
 
 class RecordRegisterEmotionSelectViewController: BaseViewController{
     
-    let mainView = RecordRegisterEmotionSelectView().then{
+    private let mainView = RecordRegisterEmotionSelectView().then{
         $0.completeButton.addTarget(self, action: #selector(completeButtonDidClicked), for: .touchUpInside)
     }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
+    private let viewModel = RecordRegisterEmotionSelectViewModel(createRecordUseCase: DefaultCreateRecordUseCase())
+    
+    //MARK: - Override
     
     override func style(){
-        
         super.style()
-        
         setEtcButton(title: "닫기")
     }
     
@@ -30,7 +27,6 @@ class RecordRegisterEmotionSelectViewController: BaseViewController{
         super.layout()
         
         self.view.addSubview(mainView)
-        
         mainView.snp.makeConstraints{
             $0.top.equalToSuperview().offset(Offset.VIEW_CONTROLLER_TOP)
             $0.leading.trailing.equalToSuperview()
@@ -46,6 +42,12 @@ class RecordRegisterEmotionSelectViewController: BaseViewController{
         mainView.whatEmotionView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(emotionViewDidClicked(_:))))
         mainView.sadEmotionView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(emotionViewDidClicked(_:))))
     }
+    
+    override func bind(){
+        let input = RecordRegisterEmotionSelectViewModel.Input()
+    }
+    
+    //MARK: - Helper
     
     @objc func completeButtonDidClicked(){
         

--- a/POME/Presentation/ViewControllers/Register/AddFriend/FriendSearchViewController.swift
+++ b/POME/Presentation/ViewControllers/Register/AddFriend/FriendSearchViewController.swift
@@ -33,7 +33,8 @@ class FriendSearchViewController: BaseViewController {
         
         self.view.addSubview(friendSearchView)
         friendSearchView.snp.makeConstraints { make in
-            make.leading.trailing.bottom.equalToSuperview()
+            make.leading.trailing.equalToSuperview()
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide)
             make.top.equalTo(super.navigationView.snp.bottom)
         }
         

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -33,12 +33,6 @@ class ReviewViewController: BaseTabViewController {
     }
     
     var emptyView: ReviewEmptyView!
-
-    //MARK: - LifeCycle
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
     
     //MARK: - Method
     
@@ -57,8 +51,7 @@ class ReviewViewController: BaseTabViewController {
             filterView.setFilterSelectState(emotion: emotion)
         }
         
-        sheet.loadViewIfNeeded()
-        self.present(sheet, animated: true, completion: nil)
+        _ = sheet.loadAndShowBottomSheet(in: self)
     }
     
     @objc func reloadingButtonDidClicked(){
@@ -68,16 +61,11 @@ class ReviewViewController: BaseTabViewController {
     
     //MARK: - Override
     
-    override func style(){
-        super.style()
-    }
-    
     override func layout(){
         
         super.layout()
         
         self.view.addSubview(mainView)
-        
         mainView.snp.makeConstraints{
             $0.top.equalToSuperview().offset(Offset.VIEW_CONTROLLER_TOP)
             $0.leading.trailing.bottom.equalToSuperview()
@@ -118,7 +106,6 @@ extension ReviewViewController: UICollectionViewDelegate, UICollectionViewDataSo
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         
         let testLabel = UILabel().then{
-            
             $0.text = goalCategoryList.isEmpty ? "···" : goalCategoryList[indexPath.row]
             $0.setTypoStyleWithSingleLine(typoStyle: .title4)
         }
@@ -133,7 +120,6 @@ extension ReviewViewController: UICollectionViewDelegate, UICollectionViewDataSo
         if(selectedGoalCategory == 0 && indexPath.row != 0){
             guard let cell = collectionView.cellForItem(at: [0,0]) as? GoalCategoryCollectionViewCell else { return }
             cell.setUnselectState()
-            return
         }
         cell.setSelectState()
     }

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -20,7 +20,7 @@ class ReviewViewController: BaseTabViewController {
     
     var goalCategoryList: [String] = ["카테고리","카페", "운동","고양이", "탐앤탐스으"]
     
-    var consumeList = [String?](repeating: nil, count: 10){
+    var consumeList = [Reaction?](repeating: nil, count: 10){
         didSet{
             mainView.consumeTableView.reloadData()
         }
@@ -79,6 +79,11 @@ class ReviewViewController: BaseTabViewController {
         mainView.consumeTableView.separatorStyle = .none
         mainView.consumeTableView.delegate = self
         mainView.consumeTableView.dataSource = self
+    }
+    
+    override func topBtnDidClicked() {
+        let vc = NotificationViewController()
+        self.navigationController?.pushViewController(vc, animated: true)
     }
 }
 
@@ -151,6 +156,13 @@ extension ReviewViewController: UITableViewDelegate, UITableViewDataSource{
         guard let cell = tableView.dequeueReusableCell(withIdentifier: ConsumeReviewTableViewCell.cellIdentifier, for: indexPath) as? ConsumeReviewTableViewCell else { return UITableViewCell() }
         cell.mainView.firstEmotionTag.setTagInfo(when: .first, state: .happy)
         cell.mainView.secondEmotionTag.setTagInfo(when: .second, state: .sad)
+        
+        if let reaction = consumeList[indexPath.row] {
+            cell.mainView.myReactionBtn.setImage(reaction.defaultImage, for: .normal)
+        }
+        cell.mainView.setOthersReaction(count: indexPath.row)
+//        cell.delegate = self
+        
         return cell
     }
     
@@ -159,6 +171,4 @@ extension ReviewViewController: UITableViewDelegate, UITableViewDataSource{
         let vc = ReviewDetailViewController()
         self.navigationController?.pushViewController(vc, animated: true)
     }
-    
-    
 }

--- a/POME/Presentation/Views/Goal/GoalContentView.swift
+++ b/POME/Presentation/Views/Goal/GoalContentView.swift
@@ -50,13 +50,9 @@ class GoalContentView: BaseView {
     lazy var completeButton = DefaultButton(titleStr: "작성했어요").then{
         $0.isActivate(false)
     }
-
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-    }
     
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    func changeGoalMakePublicViewStatus(with: Bool){
+        goalMakePublicView.backgroundColor =  with ? Color.pink10 : Color.grey1
     }
     
     override func hierarchy() {
@@ -119,6 +115,5 @@ class GoalContentView: BaseView {
             $0.bottom.equalToSuperview()
             $0.height.equalTo(52)
         }
-        
     }
 }

--- a/POME/Presentation/Views/Record/Register/RecordRegisterContentView.swift
+++ b/POME/Presentation/Views/Record/Register/RecordRegisterContentView.swift
@@ -9,12 +9,11 @@ import UIKit
 
 struct PomeDateFormatter{
     
+    static let formatter = DateFormatter().then{
+        $0.dateFormat = "yyyy.MM.dd"
+    }
+    
     static func getTodayDate() -> String{
-        
-        let formatter = DateFormatter().then{
-            $0.dateFormat = "yyyy.MM.dd"
-        }
-        
         return formatter.string(from: Date())
     }
     
@@ -24,6 +23,10 @@ struct PomeDateFormatter{
     
     static private func convertIntToFormatterString(_ int: Int) -> String{
         int < 10 ? "0\(int)" : String(int)
+    }
+    
+    static func getDateType(from: String){
+        formatter.date(from: from)
     }
 }
 

--- a/POME/Presentation/Views/Record/Register/RecordRegisterEmotionSelectView.swift
+++ b/POME/Presentation/Views/Record/Register/RecordRegisterEmotionSelectView.swift
@@ -22,7 +22,9 @@ class RecordRegisterEmotionSelectView: BaseView {
     let whatEmotionView = FirstEmotionView.generateWithInfo(emotion: .what)
     let sadEmotionView = FirstEmotionView.generateWithInfo(emotion: .sad)
     
-    lazy var completeButton = DefaultButton(titleStr: "남겼어요")
+    lazy var completeButton = DefaultButton(titleStr: "남겼어요").then{
+        $0.isActivate = false
+    }
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/POME/Presentation/Views/Review/ReviewDetailView.swift
+++ b/POME/Presentation/Views/Review/ReviewDetailView.swift
@@ -14,18 +14,14 @@ class ReviewDetailView: BaseView {
         $0.spacing = 2
         $0.axis = .horizontal
     }
-    
     var firstEmotionTag = EmotionTagView()
-    
     var secondEmotionTag = EmotionTagView()
     
     let tagArrowBackgroundView = UIView()
-    
     let tagArrowImage = UIImageView().then{
         $0.image = Image.tagArrow
     }
     
-    //
     let priceLabel = UILabel().then{
         $0.text = "320,800원"
         $0.textColor = Color.title
@@ -37,55 +33,37 @@ class ReviewDetailView: BaseView {
         $0.setTypoStyleWithMultiLine(typoStyle: .body2)
         $0.numberOfLines = 0
     }
-    
-    //
-    
+
     let etcStackView = UIStackView().then{
         $0.spacing = 2
         $0.axis = .horizontal
     }
-    
     let tagLabel = PaddingLabel().then{
         $0.text = "커피 대신 물을 마시자"
         $0.textColor = Color.grey5
         $0.setTypoStyleWithSingleLine(typoStyle: .body3)
     }
-    
     let timeLabel = UILabel().then{
         $0.text = "· 44분 전"
         $0.textColor = Color.grey5
         $0.setTypoStyleWithSingleLine(typoStyle: .body3)
     }
     
-    //
     let reactionStackView = UIStackView().then{
         $0.spacing = -6
         $0.axis = .horizontal
     }
-    
     lazy var myReactionBtn = UIButton().then{
         $0.setImage(Image.emojiAdd, for: .normal)
     }
-    
     lazy var othersReactionButton = UIButton()
-    
     lazy var othersReactionCountLabel = UILabel().then{
         $0.setTypoStyleWithMultiLine(typoStyle: .subtitle3)
         $0.textColor = .white
         $0.isUserInteractionEnabled = false
     }
-    
     lazy var moreButton = UIButton().then{
         $0.setImage(Image.moreHorizontal, for: .normal)
-    }
-    
-    //MARK: - LifeCycle
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
     
     override func hierarchy() {
@@ -181,5 +159,36 @@ class ReviewDetailView: BaseView {
             $0.width.equalTo(23)
             $0.height.equalTo(22)
         }
+    }
+    
+    func setOthersReaction(count: Int){
+        
+        if(count == 0){
+            //TODO: 0개일 때 어떤 이모지 사용...?
+            othersReactionButton.setImage(Image.emojiAdd, for: .normal)
+            return
+        }else if(count == 1){
+            othersReactionButton.setImage(Image.emojiHappy, for: .normal)
+            return
+        }
+        
+        //count > 1인 경우 아래 코드 실행
+        self.othersReactionButton.addSubview(othersReactionCountLabel)
+
+        othersReactionCountLabel.snp.makeConstraints{
+            $0.leading.top.equalToSuperview().offset(6)
+            $0.centerX.centerY.equalToSuperview()
+        }
+        
+        let countString: String!
+        
+        if(count < 10){
+            countString = "+\(count)"
+        }else{
+            countString = "9+"
+        }
+        
+        othersReactionCountLabel.text = countString
+        othersReactionButton.setImage(Image.emojiBlurHappy, for: .normal)
     }
 }

--- a/POME/Presentation/Views/Review/ReviewView.swift
+++ b/POME/Presentation/Views/Review/ReviewView.swift
@@ -284,6 +284,5 @@ extension ReviewView{
                 $0.width.height.equalTo(14)
             }
         }
-        
     }
 }

--- a/POME/Resource/Storyboard/SSOOYA.storyboard
+++ b/POME/Resource/Storyboard/SSOOYA.storyboard
@@ -9,10 +9,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Record Register Content View Controller-->
+        <!--Goal Date View Controller-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController modalPresentationStyle="overFullScreen" id="Y6W-OH-hqX" customClass="RecordRegisterContentViewController" customModule="POME" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController modalPresentationStyle="overFullScreen" id="Y6W-OH-hqX" customClass="GoalDateViewController" customModule="POME" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/POME/Resource/Storyboard/SSOOYA.storyboard
+++ b/POME/Resource/Storyboard/SSOOYA.storyboard
@@ -9,10 +9,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Goal Date View Controller-->
+        <!--Record Register Content View Controller-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController modalPresentationStyle="overFullScreen" id="Y6W-OH-hqX" customClass="GoalDateViewController" customModule="POME" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController modalPresentationStyle="overFullScreen" id="Y6W-OH-hqX" customClass="RecordRegisterContentViewController" customModule="POME" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/POME/Resource/Storyboard/SSOOYA.storyboard
+++ b/POME/Resource/Storyboard/SSOOYA.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="7M8-Jt-7cC">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="QDQ-xh-nKn">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -9,10 +9,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Record Register Content View Controller-->
+        <!--Record Register Emotion Select View Controller-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController modalPresentationStyle="overFullScreen" id="Y6W-OH-hqX" customClass="RecordRegisterContentViewController" customModule="POME" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController modalPresentationStyle="overFullScreen" id="Y6W-OH-hqX" customClass="RecordRegisterEmotionSelectViewController" customModule="POME" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -46,7 +46,7 @@
         <!--Tab Bar Controller-->
         <scene sceneID="JtU-qz-q7N">
             <objects>
-                <tabBarController modalPresentationStyle="fullScreen" id="QDQ-xh-nKn" customClass="TabBarController" customModule="POME" customModuleProvider="target" sceneMemberID="viewController">
+                <tabBarController modalPresentationStyle="fullScreen" hidesBottomBarWhenPushed="YES" id="QDQ-xh-nKn" customClass="TabBarController" customModule="POME" customModuleProvider="target" sceneMemberID="viewController">
                     <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="LSD-61-8FT">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="49"/>
                         <autoresizingMask key="autoresizingMask"/>


### PR DESCRIPTION
## What is this PR? 🔍
 ImagePopUpVC completion 구현, 생성자 레이블 생성, show 메서드 추가

## Key Changes 🔑

1. ViewController간 연결

   - 메인 탭에서 등록 페이지등 NavigationController push 발생시 tabBar hidden 설정
   
   - 기록탭 > 목표 등록 VC 연결
   
   - 기록탭 > 소비 기록 등록 VC 연결   
   
2. UI 오류 fix

   - 회고탭 목표 선택 UI 버그 수정
   
   - FriendSearch completeButton 레이아웃 오류 수정
   
3. 회고탭 임시 데이터 설정

   - 친구탭과 동일 프로세스라서 미설정해놨던 감정 선택(내 감정/친구 감정) 버튼 UI 설정해놨습니다
   
   - floating view는 아직 적용X
   
4. 목표 등록, 소비 기록 등록 ViewModel 및 RxSwift 적용

5. ImagePopUpViewController 리팩토링 

   - 생성자 전달인자 레이블 설정 
   
      - 기존 레이블 생략으로 인해 전달인자 설정에 헷갈림 있었음. (가독성 위해 추가함)
      
   - completion 핸들러(클로저) 추가
   
      - okBtn(greenTitle인 버튼) 눌렀을 때 자동으로 Alert dismiss 진행
      
      - dismiss 이후 클로저 전달받은 곳에서 각자 처리할 이벤트 작성해주시면 됩니다 (root viewcontroller로 pop 등)

      - 사용 예시
      
      ```swift
          dialog.completion = {
              self.navigationController?.popToRootViewController(animated: true)
           }
      ```
      
   - show(in: UIViewController) 메서드 추가
   
      - 기존 modalPresentationStyle 프로퍼티 지정과 present 메서드 호출을 매번 작성해줘야 했음
      
      - show 메서드로 위의 2가지 자동으로 설정되도록 구현해놨습니다
      
      - 기존 코드는 모두 show(in:)으로 대체 완료한 상태입니다
      
      - 사용 예시
      
    ```swift
        let dialog = ImagePopUpViewController(imageValue: Image.penMint,
                                              titleText: "작성을 그만 두시겠어요?",
                                              messageText: "지금까지 작성한 내용은 모두 사라져요",
                                              greenBtnText: "그만 둘래요",
                                              grayBtnText: "이어서 쓸래요").show(in: self)
    ```
   - 마지막으로 Alert 케이스 enum 형으로 정리하기 위해 파일 추가해놨습니다. 가능하면 주말 내로 정리해볼게요~

## To Reviewers 📢
- 공통 소스 리팩토링 및 적용으로 인해 변경된 파일이 많습니다. 꼭 풀 받고 사용해주세요~

## Related Issues ⛱
#114, #121