### PR TITLE
Refactor/#121: ImageAlert enum으로 케이스 정리 및 generateAndShow 메서드 적용

### DIFF
--- a/POME/Global/Source/PopUp/AlertInfo.swift
+++ b/POME/Global/Source/PopUp/AlertInfo.swift
@@ -25,13 +25,18 @@ extension ImageAlert{
         let greyButtonTitle: String
     }
 
-    func generateAndShow(in: UIViewController) -> ImagePopUpViewController{
+    func generateAndShow(in viewController: UIViewController) -> ImagePopUpViewController{
         
-        return ImagePopUpViewController(imageValue: self.image,
-                                        titleText: self.title,
-                                        messageText: self.message,
-                                        greenBtnText: self.greenButtonTitle,
-                                        grayBtnText: self.greyButtonTitle)
+        let popup = ImagePopUpViewController(imageValue: self.image,
+                                             titleText: self.title,
+                                             messageText: self.message,
+                                             greenBtnText: self.greenButtonTitle,
+                                             grayBtnText: self.greyButtonTitle)
+        
+        popup.modalPresentationStyle = .overFullScreen
+        viewController.present(popup, animated: false)
+        
+        return popup
     }
     
     private var description: ImageAlertDescription{

--- a/POME/Global/Source/PopUp/AlertInfo.swift
+++ b/POME/Global/Source/PopUp/AlertInfo.swift
@@ -7,6 +7,89 @@
 
 import Foundation
 
-enum AlertInfo{
+enum ImageAlert{
+    case deleteInProgressGoal
+    case deleteRecord
+    case quitRecord
+    case deleteEndGoal
+    case deleteFriend
+}
+
+extension ImageAlert{
+
+    struct ImageAlertDescription{
+        let image: UIImage
+        let title: String
+        let message: String
+        let greenButtonTitle: String
+        let greyButtonTitle: String
+    }
+
+    func generateAndShow(in: UIViewController) -> ImagePopUpViewController{
+        
+        return ImagePopUpViewController(imageValue: self.image,
+                                        titleText: self.title,
+                                        messageText: self.message,
+                                        greenBtnText: self.greenButtonTitle,
+                                        grayBtnText: self.greyButtonTitle)
+    }
+    
+    private var description: ImageAlertDescription{
+        switch self{
+        case .deleteInProgressGoal:     return ImageAlertDescription(image: Image.trashGreen,
+                                                                     title: "목표를 삭제하시겠어요?",
+                                                                     message: "해당 목표에서 작성한 기록도 모두 삭제돼요",
+                                                                     greenButtonTitle: "삭제할게요",
+                                                                     greyButtonTitle: "아니요")
+            
+        case .deleteRecord:             return ImageAlertDescription(image: Image.trashGreen,
+                                                                     title: "기록을 삭제하시겠어요?",
+                                                                     message: "삭제한 내용은 다시 되돌릴 수 없어요",
+                                                                     greenButtonTitle: "삭제할게요",
+                                                                     greyButtonTitle: "아니요")
+            
+        case .quitRecord:               return ImageAlertDescription(image: Image.penMint,
+                                                                     title: "작성을 그만 두시겠어요?",
+                                                                     message: "지금까지 작성한 내용은 모두 사라져요",
+                                                                     greenButtonTitle: "그만 둘래요",
+                                                                     greyButtonTitle: "이어서 쓸래요")
+            
+        case .deleteEndGoal:            return ImageAlertDescription(image: Image.trashGreen,
+                                                                     title: "종료된 목표를 삭제할까요?",
+                                                                     message: "종료된 목표를 삭제할까요?",
+                                                                     greenButtonTitle: "삭제할게요",
+                                                                     greyButtonTitle: "아니요")
+            
+        case .deleteFriend:             return ImageAlertDescription(image: Image.trashPink,
+                                                                     title: "친구를 삭제하시겠어요?",
+                                                                     message: "친구의 씀씀이를 더 이상 볼 수 없어요",
+                                                                     greenButtonTitle: "삭제할게요",
+                                                                     greyButtonTitle: "아니요")
+        }
+    }
+    
+    private var image: UIImage{
+        self.description.image
+    }
+    
+    private var title: String{
+        self.description.title
+    }
+    
+    private var message: String{
+        self.description.message
+    }
+    
+    private var greenButtonTitle: String{
+        self.description.greenButtonTitle
+    }
+    
+    private var greyButtonTitle: String{
+        self.description.greyButtonTitle
+    }
+}
+
+//MARK: - TextAlert
+enum TextAlert{
     
 }

--- a/POME/Global/Source/PopUp/ImagePopUpViewController.swift
+++ b/POME/Global/Source/PopUp/ImagePopUpViewController.swift
@@ -39,24 +39,35 @@ class ImagePopUpViewController: UIViewController {
     var cancelBtn: UIButton!
     var okBtn: UIButton!
     // MARK: - Life Cycles
-    convenience init(imageValue: UIImage? = nil,
-                     titleText: String? = nil,
-                     messageText: String? = nil,
-                     greenBtnText: String? = nil,
-                     grayBtnText: String? = nil) {
-        self.init()
-
+//    convenience init(imageValue: UIImage? = nil,
+//                     titleText: String? = nil,
+//                     messageText: String? = nil,
+//                     greenBtnText: String? = nil,
+//                     grayBtnText: String? = nil) {
+//        self.init()
+//
+//        self.imageValue = imageValue
+//        self.titleText = titleText
+//        self.messageText = messageText
+//        self.greenBtnText = greenBtnText
+//        self.grayBtnText = grayBtnText
+//    }
+    
+    init(imageValue: UIImage,
+         titleText: String,
+         messageText: String,
+         greenBtnText: String,
+         grayBtnText: String){
         self.imageValue = imageValue
         self.titleText = titleText
         self.messageText = messageText
         self.greenBtnText = greenBtnText
         self.grayBtnText = grayBtnText
+        super.init(nibName: nil, bundle: nil)
     }
     
-    func show(in viewController: UIViewController) -> ImagePopUpViewController{
-        self.modalPresentationStyle = .overFullScreen
-        viewController.present(self, animated: false, completion: nil)
-        return self
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
     //MARK: - Override

--- a/POME/Presentation/ViewControllers/Goal/GoalContentViewController.swift
+++ b/POME/Presentation/ViewControllers/Goal/GoalContentViewController.swift
@@ -76,11 +76,7 @@ class GoalContentViewController: BaseViewController {
     //MARK: - Helper
     
     private func closeButtonDidClicked(){
-        let dialog = ImagePopUpViewController(imageValue: Image.penMint,
-                                              titleText: "작성을 그만 두시겠어요?",
-                                              messageText: "지금까지 작성한 내용은 모두 사라져요",
-                                              greenBtnText: "그만 둘래요",
-                                              grayBtnText: "이어서 쓸래요").show(in: self)
+        let dialog = ImageAlert.quitRecord.generateAndShow(in: self)
         dialog.completion = {
             self.navigationController?.popToRootViewController(animated: true)
         }

--- a/POME/Presentation/ViewControllers/Goal/GoalDateViewController.swift
+++ b/POME/Presentation/ViewControllers/Goal/GoalDateViewController.swift
@@ -66,11 +66,7 @@ class GoalDateViewController: BaseViewController {
     //MARK: - Action
     
     override func backBtnDidClicked() {
-        let dialog = ImagePopUpViewController(imageValue: Image.penMint,
-                                              titleText: "작성을 그만 두시겠어요?",
-                                              messageText: "지금까지 작성한 내용은 모두 사라져요",
-                                              greenBtnText: "그만 둘래요",
-                                              grayBtnText: "이어서 쓸래요").show(in: self)
+        let dialog = ImageAlert.quitRecord.generateAndShow(in: self)
         dialog.completion = {
             self.navigationController?.popToRootViewController(animated: true)
         }

--- a/POME/Presentation/ViewControllers/MyPage/CompletedGoalsViewController.swift
+++ b/POME/Presentation/ViewControllers/MyPage/CompletedGoalsViewController.swift
@@ -65,11 +65,7 @@ class CompletedGoalsViewController: BaseViewController {
     @objc func menuButtonDidTap() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         let deleteAction =  UIAlertAction(title: "삭제하기", style: UIAlertAction.Style.default){(_) in
-            let dialog = ImagePopUpViewController(imageValue: Image.trashGreen,
-                                                  titleText: "종료된 목표를 삭제할까요?",
-                                                  messageText: "지금까지 작성된 기록들은 모두 사라져요",
-                                                  greenBtnText: "삭제할게요",
-                                                  grayBtnText: "아니요").show(in: self)
+            let dialog = ImageAlert.deleteEndGoal.generateAndShow(in: self)
         }
         let cancelAction = UIAlertAction(title: "취소", style: UIAlertAction.Style.cancel, handler: nil)
         

--- a/POME/Presentation/ViewControllers/MyPage/MypageFriendViewController.swift
+++ b/POME/Presentation/ViewControllers/MyPage/MypageFriendViewController.swift
@@ -49,11 +49,7 @@ class MypageFriendViewController: BaseViewController {
         }
     }
     @objc func showDeleteFriendDialog() {
-        let dialog = ImagePopUpViewController(imageValue: Image.trashPink,
-                                              titleText: "친구를 삭제하시겠어요?",
-                                              messageText: "친구의 씀씀이를 더 이상 볼 수 없어요",
-                                              greenBtnText: "삭제할게요",
-                                              grayBtnText: "아니요").show(in: self)
+        let dialog = ImageAlert.deleteFriend.generateAndShow(in: self)
     }
 }
 // MARK: - TableView delegate

--- a/POME/Presentation/ViewControllers/Record/FinishGoal/AllRecordsViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/FinishGoal/AllRecordsViewController.swift
@@ -52,11 +52,7 @@ class AllRecordsViewController: BaseViewController {
             print("click modify")
         }
         let deleteAction =  UIAlertAction(title: "삭제하기", style: UIAlertAction.Style.default){(_) in
-            let dialog = ImagePopUpViewController(imageValue: Image.trashGreen,
-                                                  titleText: "기록을 삭제하시겠어요?",
-                                                  messageText: "삭제한 내용은 다시 되돌릴 수 없어요",
-                                                  greenBtnText: "삭제할게요",
-                                                  grayBtnText: "아니요").show(in: self)
+            let dialog = ImageAlert.deleteRecord.generateAndShow(in: self)
         }
         let cancelAction = UIAlertAction(title: "취소", style: UIAlertAction.Style.cancel, handler: nil)
         
@@ -69,11 +65,7 @@ class AllRecordsViewController: BaseViewController {
     @objc func alertGoalMenuButtonDidTap() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         let deleteAction =  UIAlertAction(title: "삭제하기", style: UIAlertAction.Style.default){(_) in
-            let dialog = ImagePopUpViewController(imageValue: Image.trashGreen,
-                                                  titleText: "목표를 삭제하시겠어요?",
-                                                  messageText: "해당 목표에서 작성한 기록도 모두 삭제돼요",
-                                                  greenBtnText: "삭제할게요",
-                                                  grayBtnText: "아니요").show(in: self)
+            let dialog = ImageAlert.deleteInProgressGoal.generateAndShow(in: self)
         }
         let cancelAction = UIAlertAction(title: "취소", style: UIAlertAction.Style.cancel, handler: nil)
         

--- a/POME/Presentation/ViewControllers/Record/FinishGoal/CommentViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/FinishGoal/CommentViewController.swift
@@ -48,11 +48,7 @@ class CommentViewController: BaseViewController {
         self.navigationController?.pushViewController(SubmitViewController(), animated: true)
     }
     @objc func notSubmitButtonDidTap() {
-        let dialog = ImagePopUpViewController(imageValue: Image.trashGreen,
-                                              titleText: "종료된 목표를 삭제할까요?",
-                                              messageText: "지금까지 작성된 기록들은 모두 사라져요",
-                                              greenBtnText: "삭제할게요",
-                                              grayBtnText: "아니요").show(in: self)
+        let dialog = ImageAlert.deleteEndGoal.generateAndShow(in: self)
     }
 }
 // MARK: - TextView delegate

--- a/POME/Presentation/ViewControllers/Record/RecordEmotionViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/RecordEmotionViewController.swift
@@ -42,11 +42,7 @@ class RecordEmotionViewController: BaseViewController {
             print("click modify")
         }
         let deleteAction =  UIAlertAction(title: "삭제하기", style: UIAlertAction.Style.default){(_) in
-            let dialog = ImagePopUpViewController(imageValue: Image.trashGreen,
-                                                  titleText: "기록을 삭제하시겠어요?",
-                                                  messageText: "삭제한 내용은 다시 되돌릴 수 없어요",
-                                                  greenBtnText: "삭제할게요",
-                                                  grayBtnText: "아니요").show(in: self)
+            let dialog = ImageAlert.deleteRecord.generateAndShow(in: self)
         }
         let cancelAction = UIAlertAction(title: "취소", style: UIAlertAction.Style.cancel, handler: nil)
         

--- a/POME/Presentation/ViewControllers/Record/RecordViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/RecordViewController.swift
@@ -70,11 +70,7 @@ class RecordViewController: BaseTabViewController {
     @objc func alertGoalMenuButtonDidTap() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         let deleteAction =  UIAlertAction(title: "삭제하기", style: UIAlertAction.Style.default){(_) in
-            let dialog = ImagePopUpViewController(imageValue: Image.trashGreen,
-                                                  titleText: "목표를 삭제하시겠어요?",
-                                                  messageText: "해당 목표에서 작성한 기록도 모두 삭제돼요",
-                                                  greenBtnText: "삭제할게요",
-                                                  grayBtnText: "아니요").show(in: self)
+            let dialog = ImageAlert.deleteInProgressGoal.generateAndShow(in: self)
         }
         let cancelAction = UIAlertAction(title: "취소", style: UIAlertAction.Style.cancel, handler: nil)
         
@@ -89,11 +85,7 @@ class RecordViewController: BaseTabViewController {
             print("click modify")
         }
         let deleteAction =  UIAlertAction(title: "삭제하기", style: UIAlertAction.Style.default){(_) in
-            let dialog = ImagePopUpViewController(imageValue: Image.trashGreen,
-                                                  titleText: "기록을 삭제하시겠어요?",
-                                                  messageText: "삭제한 내용은 다시 되돌릴 수 없어요",
-                                                  greenBtnText: "삭제할게요",
-                                                  grayBtnText: "아니요").show(in: self)
+            let dialog = ImageAlert.deleteRecord.generateAndShow(in: self)
         }
         let cancelAction = UIAlertAction(title: "취소", style: UIAlertAction.Style.cancel, handler: nil)
         

--- a/POME/Presentation/ViewControllers/Record/Register/RecordRegisterContentViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/RecordRegisterContentViewController.swift
@@ -130,14 +130,20 @@ class RecordRegisterContentViewController: BaseViewController {
     }
     
     override func backBtnDidClicked(){
+    
+        let dialog = ImageAlert.quitRecord.generateAndShow(in: self)
+        dialog.completion = {
+            self.navigationController?.popToRootViewController(animated: true)
+        }
+        
+        /*
         let dialog = ImagePopUpViewController(imageValue: Image.penMint,
                                               titleText: "작성을 그만 두시겠어요?",
                                               messageText: "지금까지 작성한 내용은 모두 사라져요",
                                               greenBtnText: "그만 둘래요",
                                               grayBtnText: "이어서 쓸래요").show(in: self)
-        dialog.completion = {
-            self.navigationController?.popToRootViewController(animated: true)
-        }
+         */
+
     }
     
     @objc private func keyboardWillAppear(noti: NSNotification) {

--- a/POME/Presentation/ViewControllers/Record/Register/RecordRegisterEmotionSelectViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/RecordRegisterEmotionSelectViewController.swift
@@ -91,11 +91,7 @@ class RecordRegisterEmotionSelectViewController: BaseViewController{
     }
     
     func closeButtonDidClicked(){
-        let dialog = ImagePopUpViewController(imageValue: Image.penMint,
-                                              titleText: "작성을 그만 두시겠어요?",
-                                              messageText: "지금까지 작성한 내용은 모두 사라져요",
-                                              greenBtnText: "그만 둘래요",
-                                              grayBtnText: "이어서 쓸래요").show(in: self)
+        let dialog = ImageAlert.quitRecord.generateAndShow(in: self)
         dialog.completion = {
             self.navigationController?.popToRootViewController(animated: true)
         }


### PR DESCRIPTION
## What is this PR? 🔍

ImageAlert enum으로 케이스 정리 및 generateAndShow 메서드 적용

## Key Changes 🔑

Alert에서 기록 중단, 기록/목표 삭제 등 Alert 케이스가 한정되어 있고 계속 재사용하다보니 한 곳에서 관리할 필요성을 느껴 
AlertInfo 파일 생성 및 열거형으로 관리되도록 설계했습니다. 

1. ImageAlert 케이스 아래 5가지로 정리

     - deleteInProgressGoal
     - deleteRecord
     - quitRecord
     - deleteEndGoal
     - deleteFriend
     
2. 내부 타입인 ImageAlertDescription 구조체로 Alert 정보 설정

3. generateAndShow(in:) 메서드 구현

   - 기존 (ImagePopUpViewController의 show 메서드)
   
   ```swift
   let dialog = ImagePopUpViewController(imageValue: Image.penMint,
                                         titleText: "작성을 그만 두시겠어요?",
                                         messageText: "지금까지 작성한 내용은 모두 사라져요",
                                         greenBtnText: "그만 둘래요",
                                         grayBtnText: "이어서 쓸래요").show(in: self)
   ```
   
   - NEW Ver. (ImageAlert의 generateAndShow(in:) 메서드)
   
   ```swift
   let dialog = ImageAlert.quitRecord.generateAndShow(in: self)
   ```

## To Reviewers 📢

- ImageAlert 케이스 정리 및 적용시켜놨으니 풀 받고 사용해주세요~
- 앞으로 ImageAlert 사용할 때는 위의 예시처럼.. 호출만 해주시면 됩니다


## Related Issues ⛱
close #121