### PR TITLE
Refactor/ : CellReuse 프로토콜 활용 통해 UICollectionView, UITableView 간편 설정 및 사용 메서드 추가

### DIFF
--- a/POME.xcodeproj/project.pbxproj
+++ b/POME.xcodeproj/project.pbxproj
@@ -67,6 +67,9 @@
 		23F57837292D559F002DD28E /* SettingProfileTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F57836292D559F002DD28E /* SettingProfileTableViewCell.swift */; };
 		23F8C503291AA3F700BC755E /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 23F8C505291AA3F700BC755E /* InfoPlist.strings */; };
 		30BF6A63651FE45788387336 /* Pods_POME.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09C9BF2EA39F1113B7B22706 /* Pods_POME.framework */; };
+		570304C0297818ED00AAC56D /* CellReuse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570304BF297818ED00AAC56D /* CellReuse.swift */; };
+		570304C22978192100AAC56D /* UICollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570304C12978192100AAC56D /* UICollectionView.swift */; };
+		570304C42978193E00AAC56D /* UITableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570304C32978193E00AAC56D /* UITableView.swift */; };
 		5724EBE729100C8500DC529B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5724EBE629100C8500DC529B /* AppDelegate.swift */; };
 		5724EBE929100C8500DC529B /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5724EBE829100C8500DC529B /* SceneDelegate.swift */; };
 		5724EBEB29100C8500DC529B /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5724EBEA29100C8500DC529B /* BaseViewController.swift */; };
@@ -253,6 +256,9 @@
 		23F8C506291AA42900BC755E /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		2FE5DF366839419651B33311 /* Pods-POMETests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-POMETests.release.xcconfig"; path = "Target Support Files/Pods-POMETests/Pods-POMETests.release.xcconfig"; sourceTree = "<group>"; };
 		47547FEA22B2A0C8326E18A9 /* Pods_POME_POMEUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_POME_POMEUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		570304BF297818ED00AAC56D /* CellReuse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellReuse.swift; sourceTree = "<group>"; };
+		570304C12978192100AAC56D /* UICollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICollectionView.swift; sourceTree = "<group>"; };
+		570304C32978193E00AAC56D /* UITableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITableView.swift; sourceTree = "<group>"; };
 		5724EBE329100C8500DC529B /* POME.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = POME.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5724EBE629100C8500DC529B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5724EBE829100C8500DC529B /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -811,6 +817,8 @@
 				5724EC2C29162B3500DC529B /* UIFont.swift */,
 				23808776291B404A00072763 /* UITextField.swift */,
 				232B2BDE292B80EB00FFDF8B /* UILabel.swift */,
+				570304C12978192100AAC56D /* UICollectionView.swift */,
+				570304C32978193E00AAC56D /* UITableView.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -939,6 +947,7 @@
 			children = (
 				5724EC88291B7B7B00DC529B /* Delegate.swift */,
 				57556A942960380800B67369 /* Protocol.swift */,
+				570304BF297818ED00AAC56D /* CellReuse.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1645,6 +1654,7 @@
 				57543B7A2951BF3700A409E3 /* CalendarSheetView.swift in Sources */,
 				5799DB762977D474001137EA /* GoalTagsTableViewCell.swift in Sources */,
 				57397FBC296E77DE0088B5F4 /* CreateRecordUseCase.swift in Sources */,
+				570304C22978192100AAC56D /* UICollectionView.swift in Sources */,
 				5724EC5F2917736300DC529B /* MyPageViewController.swift in Sources */,
 				57CCA7AC292DE83F007E22D1 /* GoalContentView.swift in Sources */,
 				57CCA75D2925AEED007E22D1 /* FriendTableEmptyView.swift in Sources */,
@@ -1690,11 +1700,13 @@
 				5724EC84291B29A700DC529B /* EmojiFloatingCollectionViewCell.swift in Sources */,
 				57543B7C2951BF5300A409E3 /* CalendarSheetCollectionViewCell.swift in Sources */,
 				23F57834292D5460002DD28E /* SettingViewController.swift in Sources */,
+				570304C0297818ED00AAC56D /* CellReuse.swift in Sources */,
 				23F57830292D4C73002DD28E /* CompletedGoalsViewController.swift in Sources */,
 				232F3FD9292D5E40009F2EE5 /* AlarmSettingView.swift in Sources */,
 				5724EC6E2918CEFC00DC529B /* FriendTableViewCell.swift in Sources */,
 				233964A1292ECC06000F6BAC /* GoalWithProgressBarView.swift in Sources */,
 				57CCA78F292B0AF6007E22D1 /* EmotionFilterSheetCollectionViewCell.swift in Sources */,
+				570304C42978193E00AAC56D /* UITableView.swift in Sources */,
 				5724EC592917734C00DC529B /* RecordViewController.swift in Sources */,
 				23B3B7DF29319425008CB960 /* SecondEmotionView.swift in Sources */,
 				5799DB7A2977D487001137EA /* ReviewFilterTableViewCell.swift in Sources */,

--- a/POME/Domain/ViewModels/Goal/GoalDateRegisterViewModel.swift
+++ b/POME/Domain/ViewModels/Goal/GoalDateRegisterViewModel.swift
@@ -20,6 +20,7 @@ class GoalDateRegisterViewModel{
     }
     
     struct Output{
+        let canSelectEndDate: Driver<Bool>
         let canMoveNext: Driver<Bool>
     }
     
@@ -31,11 +32,17 @@ class GoalDateRegisterViewModel{
         
         let requestObservable = Observable.combineLatest(input.startDateTextField, input.endDateTextField)
         
+        let canSelectEndDate = input.startDateTextField
+            .map { date in
+                return !date.isEmpty
+            }.asDriver(onErrorJustReturn: false)
+        
         let canMoveNext = requestObservable
             .map { startDate, endDate in
                 return !startDate.isEmpty && !endDate.isEmpty
             }.asDriver(onErrorJustReturn: false)
 
-        return Output(canMoveNext: canMoveNext)
+        return Output(canSelectEndDate: canSelectEndDate,
+                      canMoveNext: canMoveNext)
     }
 }

--- a/POME/Global/Resource/Extension/UICollectionView.swift
+++ b/POME/Global/Resource/Extension/UICollectionView.swift
@@ -1,0 +1,27 @@
+//
+//  UICollectionView.swift
+//  POME
+//
+//  Created by 박지윤 on 2023/01/18.
+//
+
+import Foundation
+
+extension UICollectionView{
+    
+    final func register<T: BaseCollectionViewCell>(cellType: T.Type) {
+        self.register(cellType.self, forCellWithReuseIdentifier: cellType.cellIdentifier)
+    }
+    
+    final func dequeueReusableCell<T: BaseCollectionViewCell>(for indexPath: IndexPath, cellType: T.Type = T.self) -> T {
+        let bareCell = self.dequeueReusableCell(withReuseIdentifier: cellType.cellIdentifier, for: indexPath)
+        guard let cell = bareCell as? T else {
+          fatalError(
+            "Failed to dequeue a cell with identifier \(cellType.cellIdentifier) matching type \(cellType.self). "
+              + "Check that the reuseIdentifier is set properly in your XIB/Storyboard "
+              + "and that you registered the cell beforehand"
+          )
+        }
+        return cell
+    }
+}

--- a/POME/Global/Resource/Extension/UITableView.swift
+++ b/POME/Global/Resource/Extension/UITableView.swift
@@ -1,0 +1,26 @@
+//
+//  UITableView.swift
+//  POME
+//
+//  Created by 박지윤 on 2023/01/18.
+//
+
+import Foundation
+
+extension UITableView{
+    
+    final func register<T: BaseTableViewCell>(cellType: T.Type) {
+        self.register(cellType.self, forCellReuseIdentifier: cellType.cellIdentifier)
+    }
+    
+    final func dequeueReusableCell<T: BaseTableViewCell>(for indexPath: IndexPath, cellType: T.Type = T.self) -> T {
+        guard let cell = self.dequeueReusableCell(withIdentifier: cellType.cellIdentifier, for: indexPath) as? T else {
+          fatalError(
+            "Failed to dequeue a cell with identifier \(cellType.cellIdentifier) matching type \(cellType.self). "
+              + "Check that the reuseIdentifier is set properly in your XIB/Storyboard "
+              + "and that you registered the cell beforehand"
+          )
+        }
+        return cell
+    }
+}

--- a/POME/Global/Source/Base/BaseCollectionViewCell.swift
+++ b/POME/Global/Source/Base/BaseCollectionViewCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class BaseCollectionViewCell: UICollectionViewCell {
+class BaseCollectionViewCell: UICollectionViewCell, CellReuse {
     
     let baseView = UIView()
     

--- a/POME/Global/Source/Base/BaseTableViewCell.swift
+++ b/POME/Global/Source/Base/BaseTableViewCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class BaseTableViewCell: UITableViewCell {
+class BaseTableViewCell: UITableViewCell, CellReuse {
     
     let baseView = UIView()
 //        .then{

--- a/POME/Global/Source/Calendar/CalendarSheetCollectionViewCell.swift
+++ b/POME/Global/Source/Calendar/CalendarSheetCollectionViewCell.swift
@@ -15,21 +15,11 @@ class CalendarSheetCollectionViewCell: BaseCollectionViewCell {
         case disabled
     }
     
-    static let cellIdentifier = "CalendarSheetCollectionViewCell"
-    
     static let cellSize: CGFloat = (Device.WIDTH - 40 - 9.17*6) / 7
     
     let infoLabel = UILabel().then{
         $0.textAlignment = .center
         $0.setTypoStyleWithSingleLine(typoStyle: .title4)
-    }
-    
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
     
     override func prepareForReuse() {
@@ -43,16 +33,12 @@ class CalendarSheetCollectionViewCell: BaseCollectionViewCell {
     }
     
     override func hierarchy(){
-        
         super.hierarchy()
-        
         self.baseView.addSubview(infoLabel)
     }
     
     override func layout(){
-        
         super.layout()
-        
         infoLabel.snp.makeConstraints{
             $0.top.leading.equalToSuperview().offset(10)
             $0.centerX.centerY.equalToSuperview()
@@ -85,7 +71,7 @@ class CalendarSheetCollectionViewCell: BaseCollectionViewCell {
 
 extension CalendarSheetCollectionViewCell.CalendarCellState{
     
-    struct CellStateAttribute{
+    private struct CellStateAttribute{
         let backgroundColor: UIColor
         let textColor: UIColor
     }

--- a/POME/Global/Source/Calendar/CalendarSheetView.swift
+++ b/POME/Global/Source/Calendar/CalendarSheetView.swift
@@ -45,6 +45,7 @@ class CalendarSheetView: BaseView {
         $0.showsVerticalScrollIndicator = false
         $0.isScrollEnabled = false
         $0.register(CalendarSheetCollectionViewCell.self, forCellWithReuseIdentifier: CalendarSheetCollectionViewCell.cellIdentifier)
+        $0.register(cellType: CalendarSheetCollectionViewCell.self)
         
     }
     

--- a/POME/Global/Source/Calendar/CalendarSheetViewController.swift
+++ b/POME/Global/Source/Calendar/CalendarSheetViewController.swift
@@ -160,8 +160,8 @@ extension CalendarSheetViewController: UICollectionViewDelegate, UICollectionVie
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarSheetCollectionViewCell.cellIdentifier, for: indexPath) as? CalendarSheetCollectionViewCell else { return UICollectionViewCell() }
+        let cell = collectionView.dequeueReusableCell(for: indexPath, cellType: CalendarSheetCollectionViewCell.self)
+//        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarSheetCollectionViewCell.cellIdentifier, for: indexPath) as? CalendarSheetCollectionViewCell else { return UICollectionViewCell() }
         
         let index = indexPath.row
         

--- a/POME/Global/Source/Protocol/CellReuse.swift
+++ b/POME/Global/Source/Protocol/CellReuse.swift
@@ -1,0 +1,18 @@
+//
+//  CellReuse.swift
+//  POME
+//
+//  Created by 박지윤 on 2023/01/18.
+//
+
+import Foundation
+
+protocol CellReuse{
+    static var cellIdentifier: String { get }
+}
+
+extension CellReuse{
+    static var cellIdentifier: String {
+        String(describing: self)
+    }
+}

--- a/POME/Global/Source/Register/RegisterCommonView.swift
+++ b/POME/Global/Source/Register/RegisterCommonView.swift
@@ -123,7 +123,6 @@ class CommonRightButtonTextFieldView: RegisterCommonTextFieldView{
     }
     
     override func style() {
-        
         infoTextField.addRightPadding(50)
         infoTextField.isUserInteractionEnabled = false
     }

--- a/POME/Presentation/ViewControllers/Goal/GoalDateViewController.swift
+++ b/POME/Presentation/ViewControllers/Goal/GoalDateViewController.swift
@@ -29,9 +29,12 @@ class GoalDateViewController: BaseViewController {
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(self.view.safeAreaLayoutGuide)
         }
+        
+        print(mainView.endDateField.isUserInteractionEnabled)
     }
     
     override func bind(){
+        print(mainView.endDateField.isUserInteractionEnabled, "check")
         let input = GoalDateRegisterViewModel.Input(startDateTextField:
                                                         mainView.startDateField.infoTextField.rx.text.orEmpty.asObservable(),
                                                     endDateTextField:
@@ -39,10 +42,6 @@ class GoalDateViewController: BaseViewController {
                                                     completeButtonControlEvent: mainView.completButton.rx.tap)
         
         let output = viewModel.transform(input: input)
-        
-        output.canMoveNext
-            .drive(mainView.completButton.rx.isActivate)
-            .disposed(by: disposeBag)
         
         mainView.completButton.rx.tap
             .bind{
@@ -54,13 +53,20 @@ class GoalDateViewController: BaseViewController {
             .bind(onNext: { sender in
                 self.calendarSheetWillShow(sender)
             }).disposed(by: disposeBag)
-        
-        
+
         mainView.endDateField.rx.tapGesture()
             .when(.recognized)
             .bind(onNext: { sender in
                 self.calendarSheetWillShow(sender)
             }).disposed(by: disposeBag)
+        
+        output.canMoveNext
+            .drive(mainView.completButton.rx.isActivate)
+            .disposed(by: disposeBag)
+        
+        output.canSelectEndDate
+            .drive(mainView.endDateField.rx.isUserInteractionEnabled)
+            .disposed(by: disposeBag)
     }
     
     //MARK: - Action
@@ -73,12 +79,8 @@ class GoalDateViewController: BaseViewController {
     }
     
     private func calendarSheetWillShow(_ sender: UITapGestureRecognizer){
-        
+        print(mainView.endDateField.isUserInteractionEnabled)
         guard let dateField = sender.view as? CommonRightButtonTextFieldView else { return }
-        
-        /*
-        let sheet = CalendarSheetViewController().loadAndShowBottomSheet(in: self)
-        */
         
         let sheet: CalendarSheetViewController = sender == mainView.startDateField ? CalendarSheetViewController() : EndDateCalendarSheetViewController(with: startDate)
         

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -18,9 +18,8 @@ class ReviewViewController: BaseTabViewController {
     
     var selectedGoalCategory: Int = 0
     
-    var goalCategoryList: [String] = ["카테고리","카페", "운동","고양이", "탐앤탐스으"]
-    
-    var consumeList = [Reaction?](repeating: nil, count: 10){
+    var goalTags: [String] = ["카테고리","카페", "운동","고양이", "탐앤탐스으"]
+    var consumeRecords = [Reaction?](repeating: nil, count: 10){
         didSet{
             mainView.tableView.reloadData()
         }
@@ -87,14 +86,14 @@ class ReviewViewController: BaseTabViewController {
 extension ReviewViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout{
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return goalCategoryList.count == 0 ? 1 : goalCategoryList.count
+        return goalTags.count == 0 ? 1 : goalTags.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: GoalTagCollectionViewCell.cellIdentifier, for: indexPath) as? GoalTagCollectionViewCell else { return UICollectionViewCell() }
 
-        cell.goalCategoryLabel.text = goalCategoryList.isEmpty ? "···" : goalCategoryList[indexPath.row]
+        cell.goalCategoryLabel.text = goalTags.isEmpty ? "···" : goalTags[indexPath.row]
         
         if(selectedGoalCategory == indexPath.row){
             cell.setSelectState()
@@ -108,7 +107,7 @@ extension ReviewViewController: UICollectionViewDelegate, UICollectionViewDataSo
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         
         let testLabel = UILabel().then{
-            $0.text = goalCategoryList.isEmpty ? "···" : goalCategoryList[indexPath.row]
+            $0.text = goalTags.isEmpty ? "···" : goalTags[indexPath.row]
             $0.setTypoStyleWithSingleLine(typoStyle: .title4)
         }
         
@@ -135,7 +134,7 @@ extension ReviewViewController: UICollectionViewDelegate, UICollectionViewDataSo
 extension ReviewViewController: UITableViewDelegate, UITableViewDataSource{
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if(consumeList.count == 0){
+        if(consumeRecords.count == 0){
             emptyView = ReviewEmptyView()
             self.view.addSubview(emptyView)
             emptyView.snp.makeConstraints{
@@ -146,7 +145,7 @@ extension ReviewViewController: UITableViewDelegate, UITableViewDataSource{
             emptyView = nil
         }
         
-        return consumeList.count
+        return consumeRecords.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -172,7 +171,7 @@ extension ReviewViewController: UITableViewDelegate, UITableViewDataSource{
             cell.mainView.firstEmotionTag.setTagInfo(when: .first, state: .happy)
             cell.mainView.secondEmotionTag.setTagInfo(when: .second, state: .sad)
             
-            if let reaction = consumeList[indexPath.row] {
+            if let reaction = consumeRecords[indexPath.row] {
                 cell.mainView.myReactionBtn.setImage(reaction.defaultImage, for: .normal)
             }
             cell.mainView.setOthersReaction(count: indexPath.row)

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -9,7 +9,6 @@ import UIKit
 
 class ReviewViewController: BaseTabViewController {
     
-    
     //MARK: - Properties
     /* goalCategoryList test 데이터
      1. [String]()
@@ -43,7 +42,8 @@ class ReviewViewController: BaseTabViewController {
         }
         
         sheet.filterHandler = { emotion in
-            guard let filterView = sender.superview as? ReviewFilterTableViewCell.EmotionFilterView, let emotion = EmotionTag(rawValue: emotion) else { return }
+            guard let filterView = sender.superview as? ReviewFilterTableViewCell.EmotionFilterView,
+                    let emotion = EmotionTag(rawValue: emotion) else { return }
             filterView.setFilterSelectState(emotion: emotion)
         }
         
@@ -51,9 +51,7 @@ class ReviewViewController: BaseTabViewController {
     }
     
     @objc func reloadingButtonDidClicked(){
-        
         guard let cell = mainView.tableView.cellForRow(at: [0,2]) as? ReviewFilterTableViewCell else { return }
-        
         cell.firstEmotionFilter.setFilterDefaultState()
         cell.secondEmotionFilter.setFilterDefaultState()
     }
@@ -61,10 +59,10 @@ class ReviewViewController: BaseTabViewController {
     //MARK: - Override
     
     override func layout(){
-        
         super.layout()
         
         self.view.addSubview(mainView)
+        
         mainView.snp.makeConstraints{
             $0.top.equalToSuperview().offset(Offset.VIEW_CONTROLLER_TOP)
             $0.leading.trailing.bottom.equalToSuperview()
@@ -86,7 +84,7 @@ class ReviewViewController: BaseTabViewController {
 extension ReviewViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout{
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return goalTags.count == 0 ? 1 : goalTags.count
+        goalTags.count == 0 ? 1 : goalTags.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -112,7 +110,6 @@ extension ReviewViewController: UICollectionViewDelegate, UICollectionViewDataSo
         }
         
         let width = testLabel.intrinsicContentSize.width + 12 * 2
-        
         return CGSize(width: width, height: 30)
     }
     
@@ -152,22 +149,25 @@ extension ReviewViewController: UITableViewDelegate, UITableViewDataSource{
         
         switch indexPath.row{
         case 0:
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: GoalTagsTableViewCell.cellIdentifier, for: indexPath) as? GoalTagsTableViewCell else { return UITableViewCell() }
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: GoalTagsTableViewCell.cellIdentifier,
+                                                           for: indexPath) as? GoalTagsTableViewCell else { return UITableViewCell() }
             cell.tagCollectionView.delegate = self
             cell.tagCollectionView.dataSource = self
             return cell
         case 1:
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: GoalDetailTableViewCell.cellIdentifier, for: indexPath) as? GoalDetailTableViewCell else { return UITableViewCell() }
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: GoalDetailTableViewCell.cellIdentifier,
+                                                           for: indexPath) as? GoalDetailTableViewCell else { return UITableViewCell() }
             return cell
         case 2:
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: ReviewFilterTableViewCell.cellIdentifier, for: indexPath) as? ReviewFilterTableViewCell else { return UITableViewCell() }
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: ReviewFilterTableViewCell.cellIdentifier,
+                                                           for: indexPath) as? ReviewFilterTableViewCell else { return UITableViewCell() }
             cell.firstEmotionFilter.filterButton.addTarget(self, action: #selector(filterButtonDidClicked), for: .touchUpInside)
             cell.secondEmotionFilter.filterButton.addTarget(self, action: #selector(filterButtonDidClicked), for: .touchUpInside)
             cell.reloadingButton.addTarget(self, action: #selector(reloadingButtonDidClicked), for: .touchUpInside)
-            
             return cell
         default:
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: ConsumeReviewTableViewCell.cellIdentifier, for: indexPath) as? ConsumeReviewTableViewCell else { return UITableViewCell() }
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: ConsumeReviewTableViewCell.cellIdentifier,
+                                                           for: indexPath) as? ConsumeReviewTableViewCell else { return UITableViewCell() }
             cell.mainView.firstEmotionTag.setTagInfo(when: .first, state: .happy)
             cell.mainView.secondEmotionTag.setTagInfo(when: .second, state: .sad)
             
@@ -181,7 +181,6 @@ extension ReviewViewController: UITableViewDelegate, UITableViewDataSource{
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        
         let vc = ReviewDetailViewController()
         self.navigationController?.pushViewController(vc, animated: true)
     }

--- a/POME/Presentation/Views/Goal/GoalDateView.swift
+++ b/POME/Presentation/Views/Goal/GoalDateView.swift
@@ -13,18 +13,12 @@ class GoalDateView: BaseView {
                                          subtitle: "최대 한달까지 목표를 세울 수 있어요")
     let startDateField = CommonRightButtonTextFieldView.generateRightButtonView(image: Image.calendar, title: "목표 시작 날짜", placeholder: "목표 시작 날짜를 선택해주세요")
     
-    let endDateField = CommonRightButtonTextFieldView.generateRightButtonView(image: Image.calendar, title: "목표 종료 날짜", placeholder: "목표 종료 날짜를 선택해주세요")
+    let endDateField = CommonRightButtonTextFieldView.generateRightButtonView(image: Image.calendar, title: "목표 종료 날짜", placeholder: "목표 종료 날짜를 선택해주세요").then{
+        $0.isUserInteractionEnabled = false
+    }
     
     lazy var completButton = DefaultButton(titleStr: "선택했어요").then{
         $0.isActivate(false)
-    }
-    
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
     }
     
     override func hierarchy() {


### PR DESCRIPTION
## What is this PR? 🔍

## Key Changes 🔑

### 1. CellReuse 프로토콜 선언

   - get 전용 프로퍼티로 cellIdentifier 선언
   
   - 이후 extension 통해 타입 이름을 기본 값으로 설정하도록 했습니다. 
   
   - BaseTableViewCell, BaseCollectionViewCell에 **채택**해놨기 때문에 하위 Cell 클래스에서 따로 지정할 필요 없습니다.
   
   - **기존에 선언해놨던 cellIdentifier들 제거해주세요.**
   
### 2. UITableView, UICollectionView extension 통한 기본 세팅 간편화 함수 추가

1. `register`

    : UICollectionView, UITableView 초기화할 때 설정하던 메서드를 cellIdentifier과 type 지정 둘 다 할 필요없게 하기 위해서 추가한 메서드 입니다. 
   
    - 활용 방식
    
    ``` swift
    let calendarCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init()).then{
        $0.register(cellType: CalendarSheetCollectionViewCell.self)
    }
    ```

2. `dequeueReusableCell`

    : `cellForItemAt` 메서드에서 reuseableCell을 반환할 때 타입 추론을 해주지 않기 때문에 매번 guard let과 타입 클래스 지정해 타입 캐스팅을 진행해야 했었습니다.
    
    타입 캐스팅과 옵셔널 제거 작업 필요 없이 바로 사용 가능하도록 메서드 추가했습니다. 
    
    - 활용 방식
    
   ``` swift
    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
        let cell = collectionView.dequeueReusableCell(for: indexPath, 
                                                      cellType: CalendarSheetCollectionViewCell.self)
        return cell
    }
   ```

### 3. 목표 등록 종료 날짜 비활성화로 기본 세팅 > 시작 날짜 선택 이후 활성화 기능 추가
   - 지난 주 대면 회의에서 질문했던 부분인데, 기획분들의 의견 반영해 수정 완료했습니다. 

## To Reviewers 📢
- 위에 내용 확인해서 코드 작성하실 때 활용해주시고, 파일 추가했으니 꼭 풀 받고 사용해주세요~


## Related Issues ⛱
