### PR TITLE
Refactor/#131: BaseRouter, MoyaService 타입 지정 수정

### DIFF
--- a/POME/Data/Model/Friend/FriendEmotionRequestModel.swift
+++ b/POME/Data/Model/Friend/FriendEmotionRequestModel.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-struct FriendEmotionRequestModel{
-    
+struct FriendEmotionRequestModel: Encodable{
+    let emotionId: Int
 }

--- a/POME/Data/Model/Friend/FriendsResponseModel.swift
+++ b/POME/Data/Model/Friend/FriendsResponseModel.swift
@@ -6,3 +6,8 @@
 //
 
 import Foundation
+
+struct FriendsResponseModel: Decodable{
+    let friendNickName: String
+    let imageKey: String
+}

--- a/POME/Data/Model/PageableModel.swift
+++ b/POME/Data/Model/PageableModel.swift
@@ -10,5 +10,5 @@ import Foundation
 struct PageableModel: Encodable{
     let page: Int
     let size: Int
-    let sort: String
+    let sort: [String]
 }

--- a/POME/Data/Model/Record/RecordRegisterRequestModel.swift
+++ b/POME/Data/Model/Record/RecordRegisterRequestModel.swift
@@ -8,5 +8,9 @@
 import Foundation
 
 struct RecordRegisterRequestModel: Encodable{
-    
+    let goalId: Int
+    let emotionId: Int
+    let usePrice: Int
+    let useDate: String
+    let useComment: String
 }

--- a/POME/Data/Service/Foundation/BaseRouter.swift
+++ b/POME/Data/Service/Foundation/BaseRouter.swift
@@ -9,7 +9,6 @@ import Foundation
 import Moya
 
 protocol BaseRouter: Moya.TargetType {
-    associatedtype ResultModel: Decodable
 }
 
 extension BaseRouter {

--- a/POME/Data/Service/Foundation/MultiMoyaService.swift
+++ b/POME/Data/Service/Foundation/MultiMoyaService.swift
@@ -12,14 +12,14 @@ class MultiMoyaService: MoyaProvider<MultiTarget> {
     
     var request: Cancellable?
     
-    func requestDecoded<T: BaseRouter>(_ target: T,
-                                           completion: @escaping (Result<T.ResultModel?, Error>) -> Void) {
+    func requestDecoded<T: BaseRouter, L: Decodable>(_ target: T,
+                                       completion: @escaping (Result<L, Error>) -> Void) {
         addObserver()
         request(MultiTarget(target)) { result in
             switch result {
             case .success(let response):
                 do {
-                    let body = try JSONDecoder().decode(T.ResultModel.self, from: response.data)
+                    let body = try JSONDecoder().decode(L.self, from: response.data)
                     completion(.success(body))
                 } catch let error {
                     completion(.failure(error))

--- a/POME/Data/Service/Foundation/MultiMoyaService.swift
+++ b/POME/Data/Service/Foundation/MultiMoyaService.swift
@@ -31,7 +31,7 @@ class MultiMoyaService: MoyaProvider<MultiTarget> {
     }
     
     func requestNoResultAPI<T: BaseRouter>(_ target: T,
-                                               completion: @escaping (Result<Int?, Error>) -> Void) {
+                                               completion: @escaping (Result<Int, Error>) -> Void) {
         addObserver()
         request = request(MultiTarget(target)) { result in
             switch result {

--- a/POME/Data/Service/Friend/FriendRouter.swift
+++ b/POME/Data/Service/Friend/FriendRouter.swift
@@ -8,16 +8,15 @@
 import Foundation
 import Moya
 
-enum FriendRouter{
-    typealias ResultModel = String //임시 설정
+enum FriendRouter: BaseRouter{
     case postEmotion(id: Int, emotion: Int)
     case getFriendSearch(id: Int)
     case postFriend(id: Int)
     case deleteFriend(id: Int)
-    case getFriends
+    case getFriends(pageable: PageableModel)
 }
 
-extension FriendRouter: BaseRouter{
+extension FriendRouter{
     
     var path: String {
         switch self {
@@ -60,8 +59,9 @@ extension FriendRouter: BaseRouter{
             return .requestPlain
         case .deleteFriend:
             return .requestPlain
-        case .getFriends:
-            return .requestPlain
+        case .getFriends(let pageable):
+            return .requestParameters(parameters: ["userId": UserManager.userId ?? "",
+                                                   "pageable" : pageable], encoding: URLEncoding.queryString)
         /*
         case .renameAlbum(_, let request):
             return .requestParameters(parameters: ["name": request.name],

--- a/POME/Data/Service/Friend/FriendService.swift
+++ b/POME/Data/Service/Friend/FriendService.swift
@@ -14,31 +14,31 @@ final class FriendService: MultiMoyaService{
 
 extension FriendService{
     
-    func generateFriendEmotion(id: Int, emotion: Int, completion: @escaping (Result<Int?, Error>) -> Void) {
+    func generateFriendEmotion(id: Int, emotion: Int, completion: @escaping (Result<Int, Error>) -> Void) {
         requestNoResultAPI(FriendRouter.postEmotion(id: id, emotion: emotion)){ response in
             completion(response)
         }
     }
     
-    func getFriendSearch(id: Int, completion: @escaping (Result<Int?, Error>) -> Void) {
+    func getFriendSearch(id: Int, completion: @escaping (Result<Int, Error>) -> Void) {
         requestNoResultAPI(FriendRouter.getFriendSearch(id: id)){ response in
             completion(response)
         }
     }
     
-    func generateNewFriend(id: Int, completion: @escaping (Result<Int?, Error>) -> Void) {
+    func generateNewFriend(id: Int, completion: @escaping (Result<Int, Error>) -> Void) {
         requestNoResultAPI(FriendRouter.postFriend(id: id)){ response in
             completion(response)
         }
     }
     
-    func deleteFriend(id: Int, completion: @escaping (Result<Int?, Error>) -> Void) {
+    func deleteFriend(id: Int, completion: @escaping (Result<Int, Error>) -> Void) {
         requestNoResultAPI(FriendRouter.deleteFriend(id: id)){ response in
             completion(response)
         }
     }
     
-    func getFriends(pageable: PageableModel, completion: @escaping (Result<[FriendsResponseModel]?, Error>) -> Void) {
+    func getFriends(pageable: PageableModel, completion: @escaping (Result<[FriendsResponseModel], Error>) -> Void) {
         requestDecoded(FriendRouter.getFriends(pageable: pageable)){ response in
             completion(response)
         }

--- a/POME/Data/Service/Friend/FriendService.swift
+++ b/POME/Data/Service/Friend/FriendService.swift
@@ -38,8 +38,8 @@ extension FriendService{
         }
     }
     
-    func getFriends(id: Int, emotion: Int, completion: @escaping (Result<Int?, Error>) -> Void) {
-        requestNoResultAPI(FriendRouter.getFriends){ response in
+    func getFriends(pageable: PageableModel, completion: @escaping (Result<[FriendsResponseModel]?, Error>) -> Void) {
+        requestDecoded(FriendRouter.getFriends(pageable: pageable)){ response in
             completion(response)
         }
     }

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -14,7 +14,7 @@ class FriendViewController: BaseTabViewController {
     var currentFriendIndex: Int = 0
     var currentEmotionSelectCardIndex: Int?
 
-    var friends = [String?](repeating: nil, count: 10){
+    var friends = [FriendsResponseModel](){
         didSet{
             isFriendListEmpty()
         }
@@ -26,7 +26,9 @@ class FriendViewController: BaseTabViewController {
     }
     
     //MARK: - UI
+    
     private typealias FriendListTableViewCell = FriendView.FriendListTableViewCell
+    
     let friendView = FriendView()
     var emptyFriendView: FriendTableEmptyView?
     var emoijiFloatingView: EmojiFloatingView?{
@@ -37,6 +39,13 @@ class FriendViewController: BaseTabViewController {
     }
     
     //MARK: - Override
+    
+    override func viewDidLoad() {
+        
+        super.viewDidLoad()
+        
+        requestGetFriends()
+    }
     
     override func layout() {
         
@@ -62,10 +71,10 @@ class FriendViewController: BaseTabViewController {
     }
     
     //MARK: - Method
+    
     private func isFriendListEmpty(){
         
         if(friends.isEmpty){
-            
             emptyFriendView = FriendTableEmptyView()
             guard let emptyFriendView = emptyFriendView else { return }
 
@@ -76,11 +85,27 @@ class FriendViewController: BaseTabViewController {
                 $0.bottom.equalTo(self.view.safeAreaLayoutGuide)
             }
         }else{
-            
             guard let emptyFriendView = emptyFriendView else { return }
             emptyFriendView.removeFromSuperview()
             self.emptyFriendView = nil
         }
+    }
+    
+    //MARK: - API
+    
+    private func requestGetFriends(){
+        FriendService.shared.getFriends(pageable: PageableModel(page: 1,
+                                                                size: 10,
+                                                                sort: [])){ result in
+            switch result{
+            case .success(let data):
+                self.friends = data
+                break
+            default:
+                break
+            }
+        }
+
     }
 }
 
@@ -102,7 +127,6 @@ extension FriendViewController: UICollectionViewDelegate, UICollectionViewDataSo
     
             return cell
         }else{
-
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FriendCollectionViewCell.cellIdentifier, for: indexPath)
                     as? FriendCollectionViewCell else { fatalError() }
             
@@ -237,9 +261,7 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Frie
     }
     
     func presentReactionSheet(indexPath: IndexPath) {
-        let sheet = FriendReactionSheetViewController()
-        sheet.loadViewIfNeeded()
-        self.present(sheet, animated: true, completion: nil)
+        let sheet = FriendReactionSheetViewController().loadAndShowBottomSheet(in: self)
     }
     
     func presentEtcActionSheet(indexPath: IndexPath) {


### PR DESCRIPTION
## What is this PR? 🔍
BaseRouter, MoyaService 타입 지정 수정

## Key Changes 🔑
1. BaseRouter
   - ResultModel 연관 타입 제거
   - requestDecoded 메서드 선언하면서 타입 지정하는 것으로 수정

2. MultiMoyaService
   - requestNoResultAPI, requestDecoded 메서드에서 옵셔널 타입 제거

## To Reviewers 📢
- 풀 받고 사용해주세요

## Related Issues ⛱
#131