### PR TITLE
Fix/#131: BaseRouter baseURL 값 반환 오류 해결

### DIFF
--- a/POME.xcodeproj/project.pbxproj
+++ b/POME.xcodeproj/project.pbxproj
@@ -2114,7 +2114,7 @@
 		};
 		5724EC0E29100C8800DC529B /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 75AB6D987E0698805BA3AA4D /* Pods-POME.debug.xcconfig */;
+			baseConfigurationReference = EEB13B6E297F96FE001A8DD9 /* AppKey.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/POME/Data/Service/Foundation/BaseRouter.swift
+++ b/POME/Data/Service/Foundation/BaseRouter.swift
@@ -15,8 +15,7 @@ extension BaseRouter {
 
     var baseURL: URL {
         let url = Bundle.main.infoDictionary?["API_URL"] as? String ?? ""
-//        return URL(string: "http://" + url)!
-        return URL(string: "http://" + "52.79.89.129/api/v1")!
+        return URL(string: "http://" + url)!
     }
 
     var headers: [String: String]? {

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -11,17 +11,17 @@ class FriendViewController: BaseTabViewController {
     
     //MARK: - Property
     
-    var currentFriendIndex: Int = 0
+    var currentFriendIndex: Int = 0{
+        willSet{
+            requestGetFriendCards()
+        }
+    }
     var currentEmotionSelectCardIndex: Int?{
         get{
             self.currentEmotionSelectCardIndex ?? nil
         }
         set(value){
-            guard let value = value else {
-                self.currentEmotionSelectCardIndex = nil
-                return
-            }
-            self.currentEmotionSelectCardIndex = value - 1
+            self.currentEmotionSelectCardIndex = value == nil ? nil : value! - 1
         }
     }
 
@@ -121,7 +121,7 @@ class FriendViewController: BaseTabViewController {
     }
     
     private func requestGetFriendCards(){
-        
+        //id -> currentFriendIndex로 접근
     }
     
     private func requestGenerateFriendCardEmotion(reactionIndex: Int){
@@ -186,10 +186,13 @@ extension FriendViewController: UICollectionViewDelegate, UICollectionViewDataSo
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath){
         
         if(collectionView == emoijiFloatingView?.collectionView){
-            
             requestGenerateFriendCardEmotion(reactionIndex: indexPath.row)
-            
         }else{
+            
+            if(indexPath.row == currentFriendIndex){
+                return
+            }
+            
             if(currentFriendIndex == 0 && indexPath.row != 0){
                 guard let friendListCell = friendView.tableView.cellForRow(at: [0,0]) as? FriendListTableViewCell, let cell = friendListCell.collectionView.cellForItem(at: [0,0]) as? FriendCollectionViewCell else { return }
                 cell.setUnselectState(row: 0)
@@ -203,14 +206,11 @@ extension FriendViewController: UICollectionViewDelegate, UICollectionViewDataSo
     }
     
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-        
         guard let cell = collectionView.cellForItem(at: indexPath) as? FriendCollectionViewCell else { return }
-        
         cell.setUnselectState(row: indexPath.row)
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize{
-
         if(collectionView == emoijiFloatingView?.collectionView){
             return CGSize(width: EmojiFloatingCollectionViewCell.cellWidth, height: EmojiFloatingCollectionViewCell.cellWidth)
         }

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -55,7 +55,6 @@ class FriendViewController: BaseTabViewController {
     override func viewDidLoad() {
         
         super.viewDidLoad()
-        
         requestGetFriends()
     }
     
@@ -106,6 +105,7 @@ class FriendViewController: BaseTabViewController {
     //MARK: - API
     
     private func requestGetFriends(){
+        
         FriendService.shared.getFriends(pageable: PageableModel(page: 1,
                                                                 size: 10,
                                                                 sort: [])){ result in

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -12,11 +12,23 @@ class FriendViewController: BaseTabViewController {
     //MARK: - Property
     
     var currentFriendIndex: Int = 0
-    var currentEmotionSelectCardIndex: Int?
+    var currentEmotionSelectCardIndex: Int?{
+        get{
+            self.currentEmotionSelectCardIndex ?? nil
+        }
+        set(value){
+            guard let value = value else {
+                self.currentEmotionSelectCardIndex = nil
+                return
+            }
+            self.currentEmotionSelectCardIndex = value - 1
+        }
+    }
 
     var friends = [FriendsResponseModel](){
         didSet{
             isFriendListEmpty()
+            friendView.tableView.reloadData()
         }
     }
     var friendCards = [Reaction?](repeating: nil, count: 13){
@@ -100,12 +112,38 @@ class FriendViewController: BaseTabViewController {
             switch result{
             case .success(let data):
                 self.friends = data
+                self.requestGetFriendCards()
                 break
             default:
                 break
             }
         }
-
+    }
+    
+    private func requestGetFriendCards(){
+        
+    }
+    
+    private func requestGenerateFriendCardEmotion(reactionIndex: Int){
+        
+        guard let cellIndex = self.currentEmotionSelectCardIndex, let reaction = Reaction(rawValue: reactionIndex) else { return }
+        
+        friendCards[cellIndex] = reaction
+        
+        self.emoijiFloatingView?.dismiss()
+        
+        ToastMessageView.generateReactionToastView(type: reaction).show(in: self)
+        
+        /*
+        FriendService.shared.generateFriendEmotion(id: <#T##Int#>, emotion: <#T##Int#>){ result in
+            switch result{
+            case .success:
+                break
+            default:
+                break
+            }
+        }
+         */
     }
 }
 
@@ -149,13 +187,8 @@ extension FriendViewController: UICollectionViewDelegate, UICollectionViewDataSo
         
         if(collectionView == emoijiFloatingView?.collectionView){
             
-            guard let cellIndex = self.currentEmotionSelectCardIndex, let reaction = Reaction(rawValue: indexPath.row) else { return }
+            requestGenerateFriendCardEmotion(reactionIndex: indexPath.row)
             
-            friendCards[cellIndex] = reaction
-            
-            self.emoijiFloatingView?.dismiss()
-            
-            ToastMessageView.generateReactionToastView(type: reaction).show(in: self)
         }else{
             if(currentFriendIndex == 0 && indexPath.row != 0){
                 guard let friendListCell = friendView.tableView.cellForRow(at: [0,0]) as? FriendListTableViewCell, let cell = friendListCell.collectionView.cellForItem(at: [0,0]) as? FriendCollectionViewCell else { return }
@@ -261,7 +294,7 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Frie
     }
     
     func presentReactionSheet(indexPath: IndexPath) {
-        let sheet = FriendReactionSheetViewController().loadAndShowBottomSheet(in: self)
+        _ = FriendReactionSheetViewController().loadAndShowBottomSheet(in: self)
     }
     
     func presentEtcActionSheet(indexPath: IndexPath) {

--- a/POME/Support/Info.plist
+++ b/POME/Support/Info.plist
@@ -14,6 +14,8 @@
 		<string>Pretendard-Regular.otf</string>
 		<string>Pretendard-SemiBold.otf</string>
 	</array>
+	<key>API_URL</key>
+	<string>$(API_URL)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
## What is this PR? 🔍
BaseRouter baseURL 값 반환 오류 해결

## Key Changes 🔑

xccconfig 파일인 AppKey에 선언한 API_URL 값이 불러와지지 않은 상황

**해결** 
1. POME 프로젝트 파일 debug를 AppKey로 설정(기존 PodFile)
2. info 파일에 API_URL 프로퍼티 선언 및 값 설정

## To Reviewers 📢
- baseURL 이제 정상적으로 들어와집니다! 풀 받고 사용해주세요~

## Related Issues ⛱
#131