### PR TITLE
Feature/#143: 목표 등록, 친구탭 API 연결

### DIFF
--- a/POME/Data/Model/Friend/FriendsResponseModel.swift
+++ b/POME/Data/Model/Friend/FriendsResponseModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct FriendsResponseModel: Decodable{
+    let friendUserId: String
     let friendNickName: String
     let imageKey: String
 }

--- a/POME/Data/Model/Goal/GoalRegisterRequestModel.swift
+++ b/POME/Data/Model/Goal/GoalRegisterRequestModel.swift
@@ -6,3 +6,12 @@
 //
 
 import Foundation
+
+struct GoalRegisterRequestModel{
+    let goalCategoryId: Int
+    let startDate: String
+    let endDate: String
+    let oneLineMind: String
+    let price: Int
+    let isPublic: Bool
+}

--- a/POME/Data/Model/Goal/GoalRegisterRequestModel.swift
+++ b/POME/Data/Model/Goal/GoalRegisterRequestModel.swift
@@ -7,8 +7,9 @@
 
 import Foundation
 
-struct GoalRegisterRequestModel{
-    let goalCategoryId: Int
+struct GoalRegisterRequestModel: Encodable{
+//    let goalCategoryId: Int
+    let name: String
     let startDate: String
     let endDate: String
     let oneLineMind: String

--- a/POME/Data/Model/PageableModel.swift
+++ b/POME/Data/Model/PageableModel.swift
@@ -10,5 +10,5 @@ import Foundation
 struct PageableModel: Encodable{
     let page: Int
     let size: Int
-    let sort: [String]
+    let sort = ["string"]
 }

--- a/POME/Data/Model/PageableModel.swift
+++ b/POME/Data/Model/PageableModel.swift
@@ -12,3 +12,17 @@ struct PageableModel: Encodable{
     let size: Int
     let sort = ["string"]
 }
+
+
+protocol ConvertDictionary{
+}
+
+extension ConvertDictionary where Self: Encodable{
+    /*
+    var dictionary: [String : Any] {
+        let data = try JSONEncoder().encode(self)
+        guard let dictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String:Any] else { throw NSError() }
+        return dictionary
+    }
+     */
+}

--- a/POME/Data/Model/Record/RecordResponseModel.swift
+++ b/POME/Data/Model/Record/RecordResponseModel.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct RecordResponseModel: Decodable{
     let id: Int
+    let nickname: String
     let usePrice: Int
     let useDate: String
     let useComment: String
@@ -17,7 +18,8 @@ struct RecordResponseModel: Decodable{
 }
 
 struct EmotionResponseModel: Decodable{
-    var firstEmotion: Int
+    let firstEmotion: Int
     let secondEmotion: Int
+    var myEmotion: Int
     let friendEmotions: [Int]
 }

--- a/POME/Data/Model/Record/RecordResponseModel.swift
+++ b/POME/Data/Model/Record/RecordResponseModel.swift
@@ -24,8 +24,27 @@ struct EmotionResponseModel: Decodable{
     let friendEmotions: [Int]
 }
 
-
 extension RecordResponseModel{
+    
+    var goalPromiseBinding: String{
+        "· \(self.oneLineMind)"
+    }
+    
+    //TODO: 시간 데이터 가공
+    /*
+     당일인 경우
+     분 단위(44분 전) > 시간 단위(1시간 전)
+     
+     당일이 아닌 경우
+     소비 날짜(6월 24일) 포맷
+     */
+    var timeBinding: String{
+        "· \(self.useDate)  "
+    }
+    
+    var priceBinding: String{
+        "\(self.usePrice)원"
+    }
     
     var firstEmotionBinding: EmotionTag{
         EmotionTag(rawValue: self.emotionResponse.firstEmotion) ?? .default

--- a/POME/Data/Model/Record/RecordResponseModel.swift
+++ b/POME/Data/Model/Record/RecordResponseModel.swift
@@ -19,23 +19,36 @@ struct RecordResponseModel: Decodable{
 
 struct EmotionResponseModel: Decodable{
     let firstEmotion: Int
-    let secondEmotion: Int
-    var myEmotion: Int
+    let secondEmotion: Int?
+    var myEmotion: Int?
     let friendEmotions: [Int]
 }
 
 
 extension RecordResponseModel{
     
+    //TODO: 감정/리액션 없을 때 null
+    
     var firstEmotionBinding: EmotionTag{
-        EmotionTag(rawValue: self.emotionResponse.firstEmotion) ?? .happy
+        EmotionTag(rawValue: self.emotionResponse.firstEmotion) ?? .default
     }
     
     var secondEmotionBinding: EmotionTag{
-        EmotionTag(rawValue: self.emotionResponse.secondEmotion) ?? .happy
+        EmotionTag(rawValue: self.emotionResponse.secondEmotion ?? Const.default) ?? .default
     }
     
-    var myReactionBinding: Reaction{
-        Reaction(rawValue: self.emotionResponse.myEmotion) ?? .happy
+    var myReactionBinding: UIImage{
+        guard let reaction = self.emotionResponse.myEmotion else {
+            return Image.emojiAdd
+        }
+        return Reaction(rawValue: reaction)?.defaultImage ?? Image.emojiAdd
+    }
+    
+    var othersThumbnailReaction: Reaction{
+        Reaction(rawValue: self.emotionResponse.friendEmotions.first!) ?? .happy
+    }
+    
+    var othersReactionCount: Int{
+        self.emotionResponse.friendEmotions.count
     }
 }

--- a/POME/Data/Model/Record/RecordResponseModel.swift
+++ b/POME/Data/Model/Record/RecordResponseModel.swift
@@ -23,3 +23,19 @@ struct EmotionResponseModel: Decodable{
     var myEmotion: Int
     let friendEmotions: [Int]
 }
+
+
+extension RecordResponseModel{
+    
+    var firstEmotionBinding: EmotionTag{
+        EmotionTag(rawValue: self.emotionResponse.firstEmotion) ?? .happy
+    }
+    
+    var secondEmotionBinding: EmotionTag{
+        EmotionTag(rawValue: self.emotionResponse.secondEmotion) ?? .happy
+    }
+    
+    var myReactionBinding: Reaction{
+        Reaction(rawValue: self.emotionResponse.myEmotion) ?? .happy
+    }
+}

--- a/POME/Data/Model/Record/RecordResponseModel.swift
+++ b/POME/Data/Model/Record/RecordResponseModel.swift
@@ -6,3 +6,18 @@
 //
 
 import Foundation
+
+struct RecordResponseModel: Decodable{
+    let id: Int
+    let usePrice: Int
+    let useDate: String
+    let useComment: String
+    let oneLineMind: String
+    var emotionResponse: EmotionResponseModel
+}
+
+struct EmotionResponseModel: Decodable{
+    var firstEmotion: Int
+    let secondEmotion: Int
+    let friendEmotions: [Int]
+}

--- a/POME/Data/Model/Record/RecordResponseModel.swift
+++ b/POME/Data/Model/Record/RecordResponseModel.swift
@@ -27,8 +27,6 @@ struct EmotionResponseModel: Decodable{
 
 extension RecordResponseModel{
     
-    //TODO: 감정/리액션 없을 때 null
-    
     var firstEmotionBinding: EmotionTag{
         EmotionTag(rawValue: self.emotionResponse.firstEmotion) ?? .default
     }

--- a/POME/Data/Service/Foundation/HTTPMethodURL.swift
+++ b/POME/Data/Service/Foundation/HTTPMethodURL.swift
@@ -18,6 +18,7 @@ enum HTTPMethodURL {
     struct GET {
         static let records = HTTPMethodURL.recordsURL
         static let recordOfGoal = HTTPMethodURL.recordsURL + "/goal" //기록 페이징 조회
+        static let recordOfFriend = HTTPMethodURL.recordsURL + "/users" //기록 페이징 조회
         
         static let goal = HTTPMethodURL.goalsURL
         static let pageOfGoalCategory = HTTPMethodURL.goalsURL + "/category"

--- a/POME/Data/Service/Friend/FriendRouter.swift
+++ b/POME/Data/Service/Friend/FriendRouter.swift
@@ -14,6 +14,8 @@ enum FriendRouter: BaseRouter{
     case postFriend(id: Int)
     case deleteFriend(id: Int)
     case getFriends(pageable: PageableModel)
+    case getFriendRecord(id: String, pageable: PageableModel)
+    case getAllFriendsRecord
 }
 
 extension FriendRouter{
@@ -30,6 +32,10 @@ extension FriendRouter{
             return HTTPMethodURL.DELETE.friend + "/\(id)"
         case .getFriends:
             return HTTPMethodURL.GET.friends
+        case .getFriendRecord(let id, _):
+            return HTTPMethodURL.GET.recordOfFriend + "/\(id)"
+        case .getAllFriendsRecord:
+            return ""
         }
     }
     
@@ -44,6 +50,10 @@ extension FriendRouter{
         case .deleteFriend:
             return .delete
         case .getFriends:
+            return .get
+        case .getFriendRecord:
+            return  .get
+        case .getAllFriendsRecord:
             return .get
         }
     }
@@ -62,11 +72,18 @@ extension FriendRouter{
         case .getFriends(let pageable):
             return .requestParameters(parameters: ["userId": UserManager.userId ?? "",
                                                    "pageable" : pageable], encoding: URLEncoding.queryString)
-        /*
-        case .renameAlbum(_, let request):
-            return .requestParameters(parameters: ["name": request.name],
-                                      encoding: JSONEncoding.default)
-         */
+        case .getFriendRecord(_, let pageable):
+            return .requestParameters(parameters: ["page" : pageable.page,
+                                                   "size" : pageable.size,
+                                                   "sort" : pageable.sort], encoding: URLEncoding.queryString)
+        case .getAllFriendsRecord:
+            <#code#>
+            
+            /*
+            case .renameAlbum(_, let request):
+                return .requestParameters(parameters: ["name": request.name],
+                                          encoding: JSONEncoding.default)
+             */
         }
     }
 }

--- a/POME/Data/Service/Friend/FriendRouter.swift
+++ b/POME/Data/Service/Friend/FriendRouter.swift
@@ -77,7 +77,7 @@ extension FriendRouter{
                                                    "size" : pageable.size,
                                                    "sort" : pageable.sort], encoding: URLEncoding.queryString)
         case .getAllFriendsRecord:
-            <#code#>
+            return .requestPlain
             
             /*
             case .renameAlbum(_, let request):

--- a/POME/Data/Service/Friend/FriendService.swift
+++ b/POME/Data/Service/Friend/FriendService.swift
@@ -43,4 +43,16 @@ extension FriendService{
             completion(response)
         }
     }
+    
+    func getFriendRecord(id: String, pageable: PageableModel, completion: @escaping (Result<[RecordResponseModel], Error>) -> Void) {
+        requestDecoded(FriendRouter.getFriendRecord(id: id, pageable: pageable)){ response in
+            completion(response)
+        }
+    }
+    
+    func getAllFriendsRecord(pageable: PageableModel, completion: @escaping (Result<[FriendsResponseModel], Error>) -> Void) {
+//        requestDecoded(FriendRouter.getFriendRecord){ response in
+//            completion(response)
+//        }
+    }
 }

--- a/POME/Data/Service/Goal/GoalRouter.swift
+++ b/POME/Data/Service/Goal/GoalRouter.swift
@@ -6,3 +6,59 @@
 //
 
 import Foundation
+import Moya
+
+enum GoalRouter: BaseRouter{
+    case postGoal(request: GoalRegisterRequestModel)
+    case getGoal(id: Int)
+    case putGoal(id: Int, request: GoalRegisterRequestModel)
+    case deleteGoal(id: Int)
+    case getGoalsByCategory(id: Int, pageable: PageableModel)
+}
+
+extension GoalRouter{
+    var path: String {
+        switch self {
+        case .postGoal:
+            return HTTPMethodURL.POST.goal
+        case .getGoal(let id):
+            return HTTPMethodURL.GET.goal + "/\(id)"
+        case .putGoal(let id, _):
+            return HTTPMethodURL.PUT.goal + "/\(id)"
+        case .deleteGoal(let id):
+            return HTTPMethodURL.DELETE.goal +  "/\(id)"
+        case .getGoalsByCategory(let id, _):
+            return HTTPMethodURL.GET.pageOfGoalCategory + "/\(id)"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self{
+        case .postGoal:
+            return .post
+        case .getGoal:
+            return .get
+        case .putGoal:
+            return .put
+        case .deleteGoal:
+            return .delete
+        case .getGoalsByCategory:
+            return .get
+        }
+    }
+    
+    var task: Task {
+        switch self{
+        case .postGoal(let request):
+            return .requestPlain
+        case .getGoal:
+            return .requestPlain
+        case .putGoal(_, let request):
+            return .requestPlain
+        case .deleteGoal:
+            return .requestPlain
+        case .getGoalsByCategory(let pageable):
+            return .requestPlain
+        }
+    }
+}

--- a/POME/Data/Service/Goal/GoalRouter.swift
+++ b/POME/Data/Service/Goal/GoalRouter.swift
@@ -50,7 +50,7 @@ extension GoalRouter{
     var task: Task {
         switch self{
         case .postGoal(let request):
-            return .requestPlain
+            return .requestJSONEncodable(BaseRequestModel(request: request))
         case .getGoal:
             return .requestPlain
         case .putGoal(_, let request):

--- a/POME/Data/Service/Goal/GoalServcie.swift
+++ b/POME/Data/Service/Goal/GoalServcie.swift
@@ -6,3 +6,40 @@
 //
 
 import Foundation
+
+final class GoalServcie: MultiMoyaService{
+    static let shared = GoalServcie()
+    private init() { }
+}
+
+extension GoalServcie{
+    func generateGoal(request: GoalRegisterRequestModel, completion: @escaping (Result<Int, Error>) -> Void) {
+        requestNoResultAPI(GoalRouter.postGoal(request: request)){ response in
+            completion(response)
+        }
+    }
+    
+    func getGoal(id: Int, completion: @escaping (Result<Int, Error>) -> Void) {
+        requestNoResultAPI(GoalRouter.getGoal(id: id)){ response in
+            completion(response)
+        }
+    }
+    
+    func modifyGoal(id: Int, request: GoalRegisterRequestModel,completion: @escaping (Result<Int, Error>) -> Void) {
+        requestNoResultAPI(GoalRouter.putGoal(id: id, request: request)){ response in
+            completion(response)
+        }
+    }
+    
+    func deleteGoal(id: Int, completion: @escaping (Result<Int, Error>) -> Void) {
+        requestNoResultAPI(GoalRouter.deleteGoal(id: id)){ response in
+            completion(response)
+        }
+    }
+    
+    func getGoalByCategory(id: Int, pageable: PageableModel, completion: @escaping (Result<[FriendsResponseModel], Error>) -> Void) {
+        requestDecoded(GoalRouter.getGoalsByCategory(id: id, pageable: pageable)){ response in
+            completion(response)
+        }
+    }
+}

--- a/POME/Domain/ViewModels/Goal/GoalContentRegisterViewModel.swift
+++ b/POME/Domain/ViewModels/Goal/GoalContentRegisterViewModel.swift
@@ -20,6 +20,9 @@ class GoalContentRegisterViewModel{
     }
     
     struct Output{
+        let category: Driver<String>
+        let promise: Driver<String>
+        let price: Driver<String>
         let canMoveNext: Driver<Bool>
     }
     
@@ -33,12 +36,28 @@ class GoalContentRegisterViewModel{
                                                          input.promiseTextField,
                                                          input.priceTextField)
         
+        
+        let category = input.categoryTextField
+            .map{ $0 }
+            .asDriver(onErrorJustReturn: "")
+        
+        let promise = input.promiseTextField
+            .map{ $0 }
+            .asDriver(onErrorJustReturn: "")
+        
+        let price = input.priceTextField
+            .map{ $0 }
+            .asDriver(onErrorJustReturn: "")
+        
         let canMoveNext = requestObservable
             .map { category, promise, price in
                 return !category.isEmpty && !promise.isEmpty && !price.isEmpty
             }.asDriver(onErrorJustReturn: false)
 
-        return Output(canMoveNext: canMoveNext)
+        return Output(category: category,
+                      promise: promise,
+                      price: price,
+                      canMoveNext: canMoveNext)
     }
 }
 

--- a/POME/Global/Resource/DesignSystem/ReactionStyle.swift
+++ b/POME/Global/Resource/DesignSystem/ReactionStyle.swift
@@ -91,5 +91,4 @@ extension Reaction{
     var unselectImage: UIImage{
         return self.imageDescription.unselectIcon
     }
-
 }

--- a/POME/Global/Resource/DesignSystem/Tag/EmotionTagInfo.swift
+++ b/POME/Global/Resource/DesignSystem/Tag/EmotionTagInfo.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 enum EmotionTag: Int{
+    case `default` = -1 //Const.default
     case happy
     case what
     case sad
@@ -37,6 +38,7 @@ extension EmotionTag{
         case .happy:    return "행복해요"
         case .what:     return "모르겠어요"
         case .sad:      return "후회해요"
+        default:        return "아직 감정을 남기지 않았어요"
         }
     }
     
@@ -48,6 +50,8 @@ extension EmotionTag{
                                             secondEmotion: Image.reviewWhat)
         case .happy:    return EmotionTagIcon(firstEmotion: Image.emojiHappy,
                                             secondEmotion: Image.reviewHappy)
+        default:        return EmotionTagIcon(firstEmotion: Image.tagUnselect,
+                                              secondEmotion: Image.tagUnselect)
         }
     }
     

--- a/POME/Global/Resource/DesignSystem/Tag/EmotionTagInfo.swift
+++ b/POME/Global/Resource/DesignSystem/Tag/EmotionTagInfo.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 enum EmotionTag: Int{
-    case sad
-    case what
     case happy
+    case what
+    case sad
 }
 
 enum EmotionTime{
@@ -34,9 +34,9 @@ extension EmotionTag{
     
     var message: String{
         switch self{
-        case .sad:      return "후회해요"
-        case .what:     return "모르겠어요"
         case .happy:    return "행복해요"
+        case .what:     return "모르겠어요"
+        case .sad:      return "후회해요"
         }
     }
     

--- a/POME/Global/Source/Const.swift
+++ b/POME/Global/Source/Const.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 struct Const{
-    static let `default` = -1
+    static let `default` = -1 //enum 형 등에서 default에 매핑되는 정수 값
 }
 
 struct Device{

--- a/POME/Global/Source/Const.swift
+++ b/POME/Global/Source/Const.swift
@@ -8,6 +8,9 @@
 import Foundation
 import UIKit
 
+struct Const{
+    static let `default` = -1
+}
 
 struct Device{
     static let WIDTH: CGFloat = UIScreen.main.bounds.size.width

--- a/POME/Presentation/Utils/Goal/GoalRegisterRequestManager.swift
+++ b/POME/Presentation/Utils/Goal/GoalRegisterRequestManager.swift
@@ -14,6 +14,19 @@ class GoalRegisterRequestManager{
     
     var startDate: String = ""
     var endDate: String = ""
+    var name: String = ""
+    var isPublic: Bool = true
+    var oneLineMind: String = ""
+    var price: String = ""
     
     private init() { }
+    
+    func initialize(){
+        startDate = ""
+        endDate = ""
+        name = ""
+        isPublic = true
+        oneLineMind = ""
+        price = ""
+    }
 }

--- a/POME/Presentation/ViewControllers/Friend/FriendDetailViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendDetailViewController.swift
@@ -16,20 +16,26 @@ class FriendDetailViewController: BaseViewController {
         }
     }
     
-    let mainView = FriendDetailView().then{
-        $0.myReactionBtn.addTarget(self, action: #selector(myReactionBtnDidClicked), for: .touchUpInside)
+    let mainView = FriendDetailView()
+    let record: RecordResponseModel
+    
+    init(record: RecordResponseModel){
+        self.record = record
+        super.init(nibName: nil, bundle: nil)
     }
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
     override func style(){
-        
         super.style()
-        
-        //MARK: - 지금은 이렇게 넣지만... 데이터 바인딩할 때 데이터 한꺼번에 처리되도록 함수 만들기
-        self.setNavigationTitleLabel(title: "닉네임 입력받기")
+        self.setNavigationTitleLabel(title: record.nickname)
+    }
+    
+    override func initialize() {
+        mainView.myReactionBtn.addTarget(self, action: #selector(myReactionBtnDidClicked), for: .touchUpInside)
+        mainView.dataBinding(with: record)
     }
     
     override func layout() {
@@ -37,7 +43,6 @@ class FriendDetailViewController: BaseViewController {
         super.layout()
         
         self.view.addSubview(mainView)
-        
         mainView.snp.makeConstraints{
             $0.top.equalToSuperview().offset(Offset.VIEW_CONTROLLER_TOP + 24)
             $0.leading.equalToSuperview().offset(24)
@@ -50,17 +55,14 @@ class FriendDetailViewController: BaseViewController {
         emoijiFloatingView = EmojiFloatingView()
         
         guard let emoijiFloatingView = emoijiFloatingView else { return }
-        
         emoijiFloatingView.dismissHandler = {
             self.emoijiFloatingView = nil
         }
         
         self.view.addSubview(emoijiFloatingView)
-
         emoijiFloatingView.snp.makeConstraints{
             $0.top.bottom.leading.trailing.equalToSuperview()
         }
-        
         emoijiFloatingView.containerView.snp.makeConstraints{
             $0.top.equalTo(mainView.snp.bottom).offset(20 - 4)
         }

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -236,27 +236,22 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Frie
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 
         if(indexPath.row == 0){
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: FriendListTableViewCell.cellIdentifier, for: indexPath) as? FriendListTableViewCell else {
-                return UITableViewCell() }
-            print(cell)
+            let cell = tableView.dequeueReusableCell(for: indexPath, cellType: FriendListTableViewCell.self)
             cell.collectionView.delegate = self
             cell.collectionView.dataSource = self
             return cell
         }
         
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: FriendTableViewCell.cellIdentifier, for: indexPath)
-                as? FriendTableViewCell else { return UITableViewCell() }
-
+        let cell = tableView.dequeueReusableCell(for: indexPath, cellType: FriendTableViewCell.self)
         let cardIndex = indexPath.row - 1
-        if let reaction = friendCards[cardIndex] {
-            cell.mainView.myReactionBtn.setImage(reaction.defaultImage, for: .normal)
-        }
         
-        cell.mainView.firstEmotionTag.setTagInfo(when: .first, state: .happy)
-        cell.mainView.secondEmotionTag.setTagInfo(when: .second, state: .sad)
+        let record = friendCards[cardIndex]
         
-        cell.mainView.setOthersReaction(count: indexPath.row - 1)
-
+        cell.mainView.firstEmotionTag.setTagInfo(when: .first, state: record.firstEmotionBinding)
+        cell.mainView.secondEmotionTag.setTagInfo(when: .second, state: record.secondEmotionBinding)
+        cell.mainView.myReactionBtn.setImage(record.myReactionBinding, for: .normal)
+        record.othersReactionCount == 0 ? cell.mainView.setOthersReactionEmpty() : cell.mainView.setOthersReaction(thumbnail: record.othersThumbnailReaction, count: record.othersReactionCount)
+        
         cell.delegate = self
                 
         return cell

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -31,7 +31,7 @@ class FriendViewController: BaseTabViewController {
             friendView.tableView.reloadData()
         }
     }
-//    var friendCards = [Reaction?](){
+
     var friendCards = [RecordResponseModel](){
         didSet{
             friendView.tableView.reloadData()
@@ -122,7 +122,6 @@ extension FriendViewController{
     }
     
     private func requestGetFriendCards(){
-        //id -> currentFriendIndex로 접근
         let friendId = friends[currentFriendIndex].friendUserId
         FriendService.shared.getFriendRecord(id: friendId,
                                              pageable: PageableModel(page: 0, size: 10)){ result in
@@ -138,24 +137,21 @@ extension FriendViewController{
     
     private func requestGenerateFriendCardEmotion(reactionIndex: Int){
         
-        guard let cellIndex = self.currentEmotionSelectCardIndex, let reaction = Reaction(rawValue: reactionIndex) else { return }
+        guard let cellIndex = self.currentEmotionSelectCardIndex,
+                let reaction = Reaction(rawValue: reactionIndex) else { return }
         
-        friendCards[cellIndex] = reaction
-        
-        self.emoijiFloatingView?.dismiss()
-        
-        ToastMessageView.generateReactionToastView(type: reaction).show(in: self)
-        
-        /*
-        FriendService.shared.generateFriendEmotion(id: <#T##Int#>, emotion: <#T##Int#>){ result in
+        FriendService.shared.generateFriendEmotion(id: friendCards[cellIndex].id,
+                                                   emotion: reactionIndex){ result in
             switch result{
             case .success:
+                self.friendCards[cellIndex].emotionResponse.myEmotion = reactionIndex
+                self.emoijiFloatingView?.dismiss()
+                ToastMessageView.generateReactionToastView(type: reaction).show(in: self)
                 break
             default:
                 break
             }
         }
-         */
     }
 }
 
@@ -279,7 +275,6 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Frie
         
         guard let emoijiFloatingView = emoijiFloatingView,
               let cell = friendView.tableView.cellForRow(at: indexPath) as? FriendTableViewCell else { return }
-        
         emoijiFloatingView.dismissHandler = {
             self.currentEmotionSelectCardIndex = nil
             self.emoijiFloatingView = nil
@@ -290,7 +285,6 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Frie
         emoijiFloatingView.snp.makeConstraints{
             $0.top.bottom.leading.trailing.equalToSuperview()
         }
-        
         emoijiFloatingView.containerView.snp.makeConstraints{
             $0.top.equalTo(cell.baseView.snp.bottom).offset(-4)
         }

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 class FriendViewController: BaseTabViewController {
     
     //MARK: - Property
-    
     var currentFriendIndex: Int = 0{
         willSet{
             requestGetFriendCards()
@@ -86,6 +85,7 @@ class FriendViewController: BaseTabViewController {
     private func isFriendListEmpty(){
         
         if(friends.isEmpty){
+            
             emptyFriendView = FriendTableEmptyView()
             guard let emptyFriendView = emptyFriendView else { return }
 
@@ -240,22 +240,17 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Frie
         }
         
         let cell = tableView.dequeueReusableCell(for: indexPath, cellType: FriendTableViewCell.self)
-        
         let cardIndex = indexPath.row - 1
         let record = friendCards[cardIndex]
-        
+    
         cell.delegate = self
-        cell.mainView.firstEmotionTag.setTagInfo(when: .first, state: record.firstEmotionBinding)
-        cell.mainView.secondEmotionTag.setTagInfo(when: .second, state: record.secondEmotionBinding)
-        cell.mainView.myReactionBtn.setImage(record.myReactionBinding, for: .normal)
-        
-        record.othersReactionCount == 0 ? cell.mainView.setOthersReactionEmpty() : cell.mainView.setOthersReaction(thumbnail: record.othersThumbnailReaction, count: record.othersReactionCount)
+        cell.mainView.dataBinding(with: record)
                 
         return cell
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let vc = FriendDetailViewController()
+        let vc = FriendDetailViewController(record: friendCards[indexPath.row - 1])
         self.navigationController?.pushViewController(vc, animated: true)
     }
     

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -31,7 +31,8 @@ class FriendViewController: BaseTabViewController {
             friendView.tableView.reloadData()
         }
     }
-    var friendCards = [Reaction?](repeating: nil, count: 13){
+//    var friendCards = [Reaction?](){
+    var friendCards = [RecordResponseModel](){
         didSet{
             friendView.tableView.reloadData()
         }
@@ -53,7 +54,6 @@ class FriendViewController: BaseTabViewController {
     //MARK: - Override
     
     override func viewDidLoad() {
-        
         super.viewDidLoad()
         requestGetFriends()
     }
@@ -101,14 +101,15 @@ class FriendViewController: BaseTabViewController {
             self.emptyFriendView = nil
         }
     }
-    
-    //MARK: - API
+}
+
+//MARK: - API
+extension FriendViewController{
     
     private func requestGetFriends(){
         
         FriendService.shared.getFriends(pageable: PageableModel(page: 1,
-                                                                size: 10,
-                                                                sort: [])){ result in
+                                                                size: 10)){ result in
             switch result{
             case .success(let data):
                 self.friends = data
@@ -122,6 +123,17 @@ class FriendViewController: BaseTabViewController {
     
     private func requestGetFriendCards(){
         //id -> currentFriendIndex로 접근
+        let friendId = friends[currentFriendIndex].friendUserId
+        FriendService.shared.getFriendRecord(id: friendId,
+                                             pageable: PageableModel(page: 0, size: 10)){ result in
+            switch result{
+            case .success(let data):
+                self.friendCards = data
+                break
+            default:
+                break
+            }
+        }
     }
     
     private func requestGenerateFriendCardEmotion(reactionIndex: Int){
@@ -236,9 +248,11 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Frie
             return cell
         }
         
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: FriendTableViewCell.cellIdentifier, for: indexPath) as? FriendTableViewCell else { fatalError() }
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: FriendTableViewCell.cellIdentifier, for: indexPath)
+                as? FriendTableViewCell else { return UITableViewCell() }
 
-        if let reaction = friendCards[indexPath.row - 1] {
+        let cardIndex = indexPath.row - 1
+        if let reaction = friendCards[cardIndex] {
             cell.mainView.myReactionBtn.setImage(reaction.defaultImage, for: .normal)
         }
         

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -166,15 +166,12 @@ extension FriendViewController: UICollectionViewDelegate, UICollectionViewDataSo
 
         if(collectionView == emoijiFloatingView?.collectionView){
             
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: EmojiFloatingCollectionViewCell.cellIdentifier, for: indexPath)
-                    as? EmojiFloatingCollectionViewCell else { fatalError() }
-            
+            let cell = collectionView.dequeueReusableCell(for: indexPath, cellType: EmojiFloatingCollectionViewCell.self)
             cell.emojiImage.image = Reaction(rawValue: indexPath.row)?.defaultImage
     
             return cell
         }else{
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FriendCollectionViewCell.cellIdentifier, for: indexPath)
-                    as? FriendCollectionViewCell else { fatalError() }
+            let cell = collectionView.dequeueReusableCell(for: indexPath, cellType: FriendCollectionViewCell.self)
             
             if(indexPath.row == 0){ //친구 목록 - 전체인 경우
                 cell.profileImage.image = Image.categoryInactive
@@ -243,16 +240,16 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Frie
         }
         
         let cell = tableView.dequeueReusableCell(for: indexPath, cellType: FriendTableViewCell.self)
-        let cardIndex = indexPath.row - 1
         
+        let cardIndex = indexPath.row - 1
         let record = friendCards[cardIndex]
         
+        cell.delegate = self
         cell.mainView.firstEmotionTag.setTagInfo(when: .first, state: record.firstEmotionBinding)
         cell.mainView.secondEmotionTag.setTagInfo(when: .second, state: record.secondEmotionBinding)
         cell.mainView.myReactionBtn.setImage(record.myReactionBinding, for: .normal)
-        record.othersReactionCount == 0 ? cell.mainView.setOthersReactionEmpty() : cell.mainView.setOthersReaction(thumbnail: record.othersThumbnailReaction, count: record.othersReactionCount)
         
-        cell.delegate = self
+        record.othersReactionCount == 0 ? cell.mainView.setOthersReactionEmpty() : cell.mainView.setOthersReaction(thumbnail: record.othersThumbnailReaction, count: record.othersReactionCount)
                 
         return cell
     }
@@ -276,7 +273,6 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Frie
         }
         
         self.view.addSubview(emoijiFloatingView)
-        
         emoijiFloatingView.snp.makeConstraints{
             $0.top.bottom.leading.trailing.equalToSuperview()
         }

--- a/POME/Presentation/ViewControllers/Goal/GoalDateViewController.swift
+++ b/POME/Presentation/ViewControllers/Goal/GoalDateViewController.swift
@@ -16,7 +16,8 @@ class GoalDateViewController: BaseViewController {
     
     private let mainView = GoalDateView()
     private let viewModel = GoalDateRegisterViewModel(goalUseCase: DefaultCreateGoalUseCase(repository: DefaultGoalRepository()))
-
+    private var goalDataManager = GoalRegisterRequestManager.shared
+    
     //MARK: - Override
     
     override func layout() {
@@ -84,16 +85,17 @@ class GoalDateViewController: BaseViewController {
     }
     
     private func calendarSheetWillShow(_ sender: UITapGestureRecognizer){
-        print(mainView.endDateField.isUserInteractionEnabled)
         guard let dateField = sender.view as? CommonRightButtonTextFieldView else { return }
         
         let sheet: CalendarSheetViewController = sender == mainView.startDateField ? CalendarSheetViewController() : EndDateCalendarSheetViewController(with: startDate)
-        
         _ = sheet.loadAndShowBottomSheet(in: self)
         sheet.completion = { date in
             let dateString = PomeDateFormatter.getDateString(date)
-            if(sheet == self.mainView.startDateField){
+            if(dateField == self.mainView.startDateField){
                 self.startDate = dateString
+                self.goalDataManager.startDate = dateString
+            }else{
+                self.goalDataManager.endDate = dateString
             }
             dateField.infoTextField.text = dateString
             dateField.infoTextField.sendActions(for: .valueChanged)

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -166,9 +166,9 @@ extension ReviewViewController: UITableViewDelegate, UITableViewDataSource{
             cell.mainView.secondEmotionTag.setTagInfo(when: .second, state: .sad)
             
             if let reaction = consumeRecords[indexPath.row] {
-                cell.mainView.myReactionBtn.setImage(reaction.defaultImage, for: .normal)
+                cell.mainView.myReactionButton.setImage(reaction.defaultImage, for: .normal)
             }
-            cell.mainView.setOthersReaction(count: indexPath.row)
+//            cell.mainView.setOthersReaction(count: indexPath.row)
     //        cell.delegate = self
             return cell
         }

--- a/POME/Presentation/Views/Friend/FriendDetailView.swift
+++ b/POME/Presentation/Views/Friend/FriendDetailView.swift
@@ -26,19 +26,16 @@ class FriendDetailView: BaseView {
     }
     
     let nameLabel = UILabel().then{
-        $0.text = "규렌버"
         $0.textColor = Color.body
         $0.setTypoStyleWithMultiLine(typoStyle: .subtitle3)
     }
     
-    let tagLabel = PaddingLabel().then{
-        $0.text = "· 커피 대신 물을 마시자"
+    let goalPromiseLabel = PaddingLabel().then{
         $0.textColor = Color.grey5
         $0.setTypoStyleWithMultiLine(typoStyle: .body3)
     }
     
     let timeLabel = UILabel().then{
-        $0.text = "· 44분 전   "
         $0.textColor = Color.grey5
         $0.setTypoStyleWithMultiLine(typoStyle: .body3)
     }
@@ -61,7 +58,6 @@ class FriendDetailView: BaseView {
     
     //
     let priceLabel = UILabel().then{
-        $0.text = "320,800원"
         $0.textColor = Color.title
         $0.setTypoStyleWithMultiLine(typoStyle: .title3)
     }
@@ -103,6 +99,21 @@ class FriendDetailView: BaseView {
     }
     
     //MARK: - Method
+    
+    func dataBinding(with record: RecordResponseModel){
+        
+        nameLabel.text = record.nickname
+        goalPromiseLabel.text = record.goalPromiseBinding
+        timeLabel.text = record.timeBinding
+        priceLabel.text = record.priceBinding
+        memoLabel.text = record.oneLineMind
+        
+        firstEmotionTag.setTagInfo(when: .first, state: record.firstEmotionBinding)
+        secondEmotionTag.setTagInfo(when: .second, state: record.secondEmotionBinding)
+        myReactionBtn.setImage(record.myReactionBinding, for: .normal)
+        
+        record.othersReactionCount == 0 ? setOthersReactionEmpty() : setOthersReaction(thumbnail: record.othersThumbnailReaction, count: record.othersReactionCount)
+    }
     
     func setOthersReactionEmpty(){
         othersReactionButton.backgroundColor = .white
@@ -154,7 +165,7 @@ class FriendDetailView: BaseView {
         marginView.addSubview(moreButton)
         
         topStackView.addArrangedSubview(nameLabel)
-        topStackView.addArrangedSubview(tagLabel)
+        topStackView.addArrangedSubview(goalPromiseLabel)
         topStackView.addArrangedSubview(timeLabel)
         
         emotionStackView.addArrangedSubview(firstEmotionTag)

--- a/POME/Presentation/Views/Friend/FriendDetailView.swift
+++ b/POME/Presentation/Views/Friend/FriendDetailView.swift
@@ -104,20 +104,22 @@ class FriendDetailView: BaseView {
     
     //MARK: - Method
     
-    func setOthersReaction(count: Int){
+    func setOthersReactionEmpty(){
+        othersReactionButton.backgroundColor = .white
+        othersReactionButton.isEnabled = false
+    }
+    
+    func setOthersReaction(thumbnail: Reaction, count: Int){
         
-        if(count == 0){
-            //TODO: 0개일 때 어떤 이모지 사용...?
-            othersReactionButton.setImage(Image.emojiAdd, for: .normal)
-            return
-        }else if(count == 1){
-            othersReactionButton.setImage(Image.emojiHappy, for: .normal)
+        othersReactionButton.isEnabled = true
+        
+        if(count == 1){
+            othersReactionButton.setImage(thumbnail.defaultImage, for: .normal)
             return
         }
         
         //count > 1인 경우 아래 코드 실행
         self.othersReactionButton.addSubview(othersReactionCountLabel)
-
         othersReactionCountLabel.snp.makeConstraints{
             $0.leading.top.equalToSuperview().offset(6)
             $0.centerX.centerY.equalToSuperview()
@@ -132,7 +134,7 @@ class FriendDetailView: BaseView {
         }
         
         othersReactionCountLabel.text = countString
-        othersReactionButton.setImage(Image.emojiBlurHappy, for: .normal)
+        othersReactionButton.setImage(thumbnail.blurImage, for: .normal)
     }
     
     //MARK: - Override

--- a/POME/Presentation/Views/Review/ReviewDetailView.swift
+++ b/POME/Presentation/Views/Review/ReviewDetailView.swift
@@ -53,7 +53,7 @@ class ReviewDetailView: BaseView {
         $0.spacing = -6
         $0.axis = .horizontal
     }
-    lazy var myReactionBtn = UIButton().then{
+    lazy var myReactionButton = UIButton().then{
         $0.setImage(Image.emojiAdd, for: .normal)
     }
     lazy var othersReactionButton = UIButton()
@@ -87,7 +87,7 @@ class ReviewDetailView: BaseView {
         tagArrowBackgroundView.addSubview(tagArrowImage)
 
         reactionStackView.insertArrangedSubview(othersReactionButton, at: 0)
-        reactionStackView.insertArrangedSubview(myReactionBtn, at: 0)
+        reactionStackView.insertArrangedSubview(myReactionButton, at: 0)
     }
 
 
@@ -145,7 +145,7 @@ class ReviewDetailView: BaseView {
             $0.leading.bottom.equalToSuperview()
         }
         
-        myReactionBtn.snp.makeConstraints{
+        myReactionButton.snp.makeConstraints{
             $0.width.height.equalTo(28)
         }
         
@@ -161,14 +161,14 @@ class ReviewDetailView: BaseView {
         }
     }
     
-    func setOthersReaction(count: Int){
+    func setOthersReaction(thumnail: Reaction, count: Int){
         
         if(count == 0){
             //TODO: 0개일 때 어떤 이모지 사용...?
             othersReactionButton.setImage(Image.emojiAdd, for: .normal)
             return
         }else if(count == 1){
-            othersReactionButton.setImage(Image.emojiHappy, for: .normal)
+            othersReactionButton.setImage(thumnail.defaultImage, for: .normal)
             return
         }
         
@@ -189,6 +189,6 @@ class ReviewDetailView: BaseView {
         }
         
         othersReactionCountLabel.text = countString
-        othersReactionButton.setImage(Image.emojiBlurHappy, for: .normal)
+        othersReactionButton.setImage(thumnail.blurImage, for: .normal)
     }
 }


### PR DESCRIPTION
## What is this PR? 🔍
목표 등록, 친구탭 API 연결

## Key Changes 🔑

### 1. Goal 도메인 Router/Service/Model 설계

   - GoalRegisterRequestManager를 통해 ViewController가 전환되더라도 데이터 유지할 수 있도록 함
   (push 할 때 따로 데이터 보낼 일 없음)

### 2. PageableModel sort 프로퍼티 기본 값 설정

스웨거로 테스트해보니까 "string" 으로 값 전달해도 정상적으로 데이터 응답해오길래 일단 기본값으로 설정해놓았습니다.
혹시 문제가 있다면 나중에 수정해보는 걸로,, 전 아직 pageable의 사용방법을 모르겠씁니다...

### 3. 친구탭 API 연결

1. RecordResponseModel 

   - extension으로 binding 위한 프로퍼티 선언

2. HTTPMethodURL 케이스 추가

   - 서버에서 누락됐던 API인 친구 소비 기록 API url 케이스 추가해놓았습니다. 

3. 친구 기록에 리액션 달기 등 API 연결

### 4. EmotionTag

   - 피그마 기준으로 emotion 순서 변경해놓았습니다
   
   - 아직 감정을 선택하기 전 상태도 반영하기 위해 default 케이스 추가
   (default에 대해 열거형 rawValue 값 통일하기 위해 Const.default로 -1 값 할당)
   
   
## To Reviewers 📢
- 풀 받고 사용해주세요~


## Related Issues ⛱
close #143, close #139 