### PR TITLE
Feature/#131: 기록 생성 API 연결 및 친구탭 점검

### DIFF
--- a/POME.xcodeproj/project.pbxproj
+++ b/POME.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		A327F9890E2682D681FA0D75 /* Pods_POME_POMEUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47547FEA22B2A0C8326E18A9 /* Pods_POME_POMEUITests.framework */; };
 		EE44601F2983D1EB00B1A311 /* GoalCategoryResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE44601E2983D1EB00B1A311 /* GoalCategoryResponseModel.swift */; };
 		EE9505D1298799DB00077B28 /* PageableResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE9505D0298799DB00077B28 /* PageableResponseModel.swift */; };
+		EE9505D329879C0C00077B28 /* ControlIndexPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE9505D229879C0C00077B28 /* ControlIndexPath.swift */; };
 		EE98F0BE2980DEE7007BFCCD /* HTTPMethodURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE98F0BD2980DEE7007BFCCD /* HTTPMethodURL.swift */; };
 		EE98F0C02980DF08007BFCCD /* BaseRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE98F0BF2980DF08007BFCCD /* BaseRouter.swift */; };
 		EE98F0C22980DF14007BFCCD /* MultiMoyaService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE98F0C12980DF14007BFCCD /* MultiMoyaService.swift */; };
@@ -407,6 +408,7 @@
 		BBADA360F64B55B3A1453232 /* Pods_POMETests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_POMETests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE44601E2983D1EB00B1A311 /* GoalCategoryResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalCategoryResponseModel.swift; sourceTree = "<group>"; };
 		EE9505D0298799DB00077B28 /* PageableResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageableResponseModel.swift; sourceTree = "<group>"; };
+		EE9505D229879C0C00077B28 /* ControlIndexPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlIndexPath.swift; sourceTree = "<group>"; };
 		EE98F0BD2980DEE7007BFCCD /* HTTPMethodURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethodURL.swift; sourceTree = "<group>"; };
 		EE98F0BF2980DF08007BFCCD /* BaseRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseRouter.swift; sourceTree = "<group>"; };
 		EE98F0C12980DF14007BFCCD /* MultiMoyaService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiMoyaService.swift; sourceTree = "<group>"; };
@@ -1024,6 +1026,7 @@
 				5724EC88291B7B7B00DC529B /* Delegate.swift */,
 				57556A942960380800B67369 /* Protocol.swift */,
 				570304BF297818ED00AAC56D /* CellReuse.swift */,
+				EE9505D229879C0C00077B28 /* ControlIndexPath.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1879,6 +1882,7 @@
 				23061244292B51F200662007 /* DefaultTextField.swift in Sources */,
 				57B16853295941E000639A15 /* ToastMessageView.swift in Sources */,
 				232F3FD2292D5AAD009F2EE5 /* SettingWithSeparatorTableViewCell.swift in Sources */,
+				EE9505D329879C0C00077B28 /* ControlIndexPath.swift in Sources */,
 				23061240292B51A600662007 /* AppRegisterViewController.swift in Sources */,
 				57C481E7296ABE7C008731D9 /* GoalRegisterRequestManager.swift in Sources */,
 				23061236292B4B5E00662007 /* RecordView.swift in Sources */,

--- a/POME.xcodeproj/project.pbxproj
+++ b/POME.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 		96CC3BB984ACAEF3CFEE1D59 /* Pods_POMETests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BBADA360F64B55B3A1453232 /* Pods_POMETests.framework */; };
 		A327F9890E2682D681FA0D75 /* Pods_POME_POMEUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47547FEA22B2A0C8326E18A9 /* Pods_POME_POMEUITests.framework */; };
 		EE44601F2983D1EB00B1A311 /* GoalCategoryResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE44601E2983D1EB00B1A311 /* GoalCategoryResponseModel.swift */; };
+		EE9505D1298799DB00077B28 /* PageableResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE9505D0298799DB00077B28 /* PageableResponseModel.swift */; };
 		EE98F0BE2980DEE7007BFCCD /* HTTPMethodURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE98F0BD2980DEE7007BFCCD /* HTTPMethodURL.swift */; };
 		EE98F0C02980DF08007BFCCD /* BaseRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE98F0BF2980DF08007BFCCD /* BaseRouter.swift */; };
 		EE98F0C22980DF14007BFCCD /* MultiMoyaService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE98F0C12980DF14007BFCCD /* MultiMoyaService.swift */; };
@@ -405,6 +406,7 @@
 		99A020A78BC79702AA87A558 /* Pods-POMETests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-POMETests.debug.xcconfig"; path = "Target Support Files/Pods-POMETests/Pods-POMETests.debug.xcconfig"; sourceTree = "<group>"; };
 		BBADA360F64B55B3A1453232 /* Pods_POMETests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_POMETests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE44601E2983D1EB00B1A311 /* GoalCategoryResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalCategoryResponseModel.swift; sourceTree = "<group>"; };
+		EE9505D0298799DB00077B28 /* PageableResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageableResponseModel.swift; sourceTree = "<group>"; };
 		EE98F0BD2980DEE7007BFCCD /* HTTPMethodURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethodURL.swift; sourceTree = "<group>"; };
 		EE98F0BF2980DF08007BFCCD /* BaseRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseRouter.swift; sourceTree = "<group>"; };
 		EE98F0C12980DF14007BFCCD /* MultiMoyaService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiMoyaService.swift; sourceTree = "<group>"; };
@@ -1395,14 +1397,15 @@
 			isa = PBXGroup;
 			children = (
 				2345E1C329818848003185E0 /* BaseResponseModel.swift */,
+				EE9505D0298799DB00077B28 /* PageableResponseModel.swift */,
 				EE98F0E929810212007BFCCD /* BaseReqestModel.swift */,
+				230FD70E298626FA0043F6DA /* StatusResponseModel.swift */,
 				EE98F0EB2981024D007BFCCD /* PageableModel.swift */,
 				2345E1C0298183A5003185E0 /* User */,
 				EEE5F5E4298126AD00ECD31B /* Record */,
 				EEE5F5E5298126C200ECD31B /* Friend */,
 				EEE5F5EC2981273500ECD31B /* Goal */,
 				EEE5F5F12981279B00ECD31B /* GoalCategory */,
-				230FD70E298626FA0043F6DA /* StatusResponseModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1791,6 +1794,7 @@
 				57CCA7BE292EEA01007E22D1 /* RecordRegisterContentViewController.swift in Sources */,
 				57CCA7612925AF43007E22D1 /* FriendDetailViewController.swift in Sources */,
 				5724EBE729100C8500DC529B /* AppDelegate.swift in Sources */,
+				EE9505D1298799DB00077B28 /* PageableResponseModel.swift in Sources */,
 				5724EC702918CFA100DC529B /* BaseTableViewCell.swift in Sources */,
 				23F364D7291B7BB4009232B4 /* FriendSearchView.swift in Sources */,
 				5724EC6229177BF000DC529B /* TabBarItem.swift in Sources */,

--- a/POME/Data/Model/Goal/GoalResponseModel.swift
+++ b/POME/Data/Model/Goal/GoalResponseModel.swift
@@ -18,3 +18,8 @@ struct GoalResponseModel: Decodable {
     let startDate: String
 }
 
+extension GoalResponseModel{
+    var goalNameBinding: String{
+        self.goalCategoryResponse.name
+    }
+}

--- a/POME/Data/Model/PageableResponseModel.swift
+++ b/POME/Data/Model/PageableResponseModel.swift
@@ -1,0 +1,12 @@
+//
+//  PageableResponseModel.swift
+//  POME
+//
+//  Created by 박소윤 on 2023/01/30.
+//
+
+import Foundation
+
+struct PageableResponseModel<T: Decodable>: Decodable{
+    let content: T
+}

--- a/POME/Data/Model/Record/RecordResponseModel.swift
+++ b/POME/Data/Model/Record/RecordResponseModel.swift
@@ -66,11 +66,15 @@ extension RecordResponseModel{
         return Reaction(rawValue: reaction)?.defaultImage ?? Image.emojiAdd
     }
     
-    var othersThumbnailReaction: Reaction{
+    var othersThumbnailReactionBinding: Reaction{
         Reaction(rawValue: self.emotionResponse.friendEmotions.first!.id) ?? .happy
     }
     
-    var othersReactionCount: Int{
+    var othersReactionCountBinding: Int{
         self.emotionResponse.friendEmotions.count
+    }
+    
+    var friendReactions: [FriendReactionResponseModel]{
+        self.emotionResponse.friendEmotions
     }
 }

--- a/POME/Data/Model/Record/RecordResponseModel.swift
+++ b/POME/Data/Model/Record/RecordResponseModel.swift
@@ -21,7 +21,12 @@ struct EmotionResponseModel: Decodable{
     let firstEmotion: Int
     let secondEmotion: Int?
     var myEmotion: Int?
-    let friendEmotions: [Int]
+    let friendEmotions: [FriendReactionResponseModel]
+}
+
+struct FriendReactionResponseModel: Decodable{ //TODO: 서버 API 수정되면 타입/이름 확인하기
+    let id: Int
+    let name: String
 }
 
 extension RecordResponseModel{
@@ -62,7 +67,7 @@ extension RecordResponseModel{
     }
     
     var othersThumbnailReaction: Reaction{
-        Reaction(rawValue: self.emotionResponse.friendEmotions.first!) ?? .happy
+        Reaction(rawValue: self.emotionResponse.friendEmotions.first!.id) ?? .happy
     }
     
     var othersReactionCount: Int{

--- a/POME/Data/Service/Foundation/HTTPMethodURL.swift
+++ b/POME/Data/Service/Foundation/HTTPMethodURL.swift
@@ -27,6 +27,7 @@ enum HTTPMethodURL {
         static let friends = HTTPMethodURL.userURL + "/friends"
         
         static let goalCategory = HTTPMethodURL.goalCategoryURL
+        static let goals = HTTPMethodURL.goalsURL + "/users"
     }
     
     struct POST {

--- a/POME/Data/Service/Foundation/HTTPMethodURL.swift
+++ b/POME/Data/Service/Foundation/HTTPMethodURL.swift
@@ -19,6 +19,7 @@ enum HTTPMethodURL {
         static let records = HTTPMethodURL.recordsURL
         static let recordOfGoal = HTTPMethodURL.recordsURL + "/goal" //기록 페이징 조회
         static let recordOfFriend = HTTPMethodURL.recordsURL + "/users" //기록 페이징 조회
+        static let recordsOfAllFriend = HTTPMethodURL.recordsURL + "/friends" //기록 페이징 조회
         
         static let goal = HTTPMethodURL.goalsURL
         static let pageOfGoalCategory = HTTPMethodURL.goalsURL + "/category"

--- a/POME/Data/Service/Foundation/MultiMoyaService.swift
+++ b/POME/Data/Service/Foundation/MultiMoyaService.swift
@@ -44,7 +44,7 @@ class MultiMoyaService: MoyaProvider<MultiTarget> {
                             completion(.success(data))
                         }
                     }else{
-                        completion(.invalidSuccess(body.errorCode!))
+                        completion(.invalidSuccess(body.errorCode ?? "", body.message ?? ""))
                     }
                 } catch let error {
                     completion(.failure(error))
@@ -80,7 +80,7 @@ class MultiMoyaService: MoyaProvider<MultiTarget> {
                     if(body.success){
                         completion(.success(body.success))
                     }else{
-                        completion(.invalidSuccess(body.errorCode ?? ""))
+                        completion(.invalidSuccess(body.errorCode ?? "", body.message))
                     }
                 } catch let error {
                     completion(.failure(error))

--- a/POME/Data/Service/Foundation/NetworkResult.swift
+++ b/POME/Data/Service/Foundation/NetworkResult.swift
@@ -9,7 +9,8 @@ import Foundation
 
 enum NetworkResult<T>{
     typealias Code = String
+    typealias Message = String
     case success(T)
-    case invalidSuccess(Code)
+    case invalidSuccess(Code, Message)
     case failure(Error?)
 }

--- a/POME/Data/Service/Friend/FriendRouter.swift
+++ b/POME/Data/Service/Friend/FriendRouter.swift
@@ -15,7 +15,7 @@ enum FriendRouter: BaseRouter{
     case deleteFriend(id: String)
     case getFriends(pageable: PageableModel)
     case getFriendRecord(id: String, pageable: PageableModel)
-    case getAllFriendsRecord
+    case getAllFriendsRecord(pageable: PageableModel)
 }
 
 extension FriendRouter{
@@ -35,7 +35,7 @@ extension FriendRouter{
         case .getFriendRecord(let id, _):
             return HTTPMethodURL.GET.recordOfFriend + "/\(id)"
         case .getAllFriendsRecord:
-            return ""
+            return HTTPMethodURL.GET.recordsOfAllFriend
         }
     }
     
@@ -77,14 +77,10 @@ extension FriendRouter{
             return .requestParameters(parameters: ["page" : pageable.page,
                                                    "size" : pageable.size,
                                                    "sort" : pageable.sort], encoding: URLEncoding.queryString)
-        case .getAllFriendsRecord:
-            return .requestPlain
-            
-            /*
-            case .renameAlbum(_, let request):
-                return .requestParameters(parameters: ["name": request.name],
-                                          encoding: JSONEncoding.default)
-             */
+        case .getAllFriendsRecord(let pageable):
+            return .requestParameters(parameters: ["page" : pageable.page,
+                                                   "size" : pageable.size,
+                                                   "sort" : pageable.sort], encoding: URLEncoding.queryString)
         }
     }
 }

--- a/POME/Data/Service/Friend/FriendService.swift
+++ b/POME/Data/Service/Friend/FriendService.swift
@@ -45,7 +45,7 @@ extension FriendService{
         }
     }
     
-    func getFriendRecord(id: String, pageable: PageableModel, completion: @escaping (Result<[RecordResponseModel], Error>) -> Void) {
+    func getFriendRecord(id: String, pageable: PageableModel, completion: @escaping (NetworkResult<[RecordResponseModel]>) -> Void) {
         requestDecoded(FriendRouter.getFriendRecord(id: id, pageable: pageable)){ response in
             completion(response)
         }

--- a/POME/Data/Service/Friend/FriendService.swift
+++ b/POME/Data/Service/Friend/FriendService.swift
@@ -51,9 +51,9 @@ extension FriendService{
         }
     }
     
-    func getAllFriendsRecord(pageable: PageableModel, completion: @escaping (Result<[FriendsResponseModel], Error>) -> Void) {
-//        requestDecoded(FriendRouter.getFriendRecord){ response in
-//            completion(response)
-//        }
+    func getAllFriendsRecord(pageable: PageableModel, completion: @escaping (NetworkResult<[RecordResponseModel]>) -> Void) {
+        requestDecoded(FriendRouter.getAllFriendsRecord(pageable: pageable)){ response in
+            completion(response)
+        }
     }
 }

--- a/POME/Data/Service/Goal/GoalRouter.swift
+++ b/POME/Data/Service/Goal/GoalRouter.swift
@@ -13,7 +13,7 @@ enum GoalRouter: BaseRouter{
     case getGoal(id: Int)
     case putGoal(id: Int, request: GoalRegisterRequestModel)
     case deleteGoal(id: Int)
-    case getGoalsByCategory(id: Int, pageable: PageableModel)
+    case getGoals
 }
 
 extension GoalRouter{
@@ -27,8 +27,8 @@ extension GoalRouter{
             return HTTPMethodURL.PUT.goal + "/\(id)"
         case .deleteGoal(let id):
             return HTTPMethodURL.DELETE.goal +  "/\(id)"
-        case .getGoalsByCategory(let id, _):
-            return HTTPMethodURL.GET.pageOfGoalCategory + "/\(id)"
+        case .getGoals:
+            return HTTPMethodURL.GET.goals
         }
     }
     
@@ -42,7 +42,7 @@ extension GoalRouter{
             return .put
         case .deleteGoal:
             return .delete
-        case .getGoalsByCategory:
+        case .getGoals:
             return .get
         }
     }
@@ -57,7 +57,7 @@ extension GoalRouter{
             return .requestPlain
         case .deleteGoal:
             return .requestPlain
-        case .getGoalsByCategory(let pageable):
+        case .getGoals:
             return .requestPlain
         }
     }

--- a/POME/Data/Service/Goal/GoalServcie.swift
+++ b/POME/Data/Service/Goal/GoalServcie.swift
@@ -39,8 +39,8 @@ extension GoalServcie{
         }
     }
     
-    func getGoalByCategory(id: Int, pageable: PageableModel, completion: @escaping (Result<[FriendsResponseModel], Error>) -> Void) {
-        requestDecoded(GoalRouter.getGoalsByCategory(id: id, pageable: pageable)){ response in
+    func getUserGoals(completion: @escaping (NetworkResult<PageableResponseModel<[GoalResponseModel]>>) -> Void) {
+        requestDecoded(GoalRouter.getGoals){ response in
             completion(response)
         }
     }

--- a/POME/Data/Service/GoalCategory/GoalCategoryService.swift
+++ b/POME/Data/Service/GoalCategory/GoalCategoryService.swift
@@ -13,7 +13,7 @@ final class GoalCategoryService: MultiMoyaService{
 }
 
 extension GoalCategoryService{
-    func getGoalCategory(completion: @escaping (Result<BaseResponseModel<[GoalCategoryResponseModel]>, Error>) -> Void){
+    func getGoalCategory(completion: @escaping (NetworkResult<[GoalCategoryResponseModel]>) -> Void){
         requestDecoded(GoalCategoryRouter.getGoalCategory){ response in
             completion(response)
         }

--- a/POME/Data/Service/Record/RecordRouter.swift
+++ b/POME/Data/Service/Record/RecordRouter.swift
@@ -36,7 +36,7 @@ extension RecordRouter{
         switch self{
         case .patchRecord(_, let request):      return .requestJSONEncodable(request)
         case .deleteRecord:                     return .requestPlain
-        case .postRecord(let request):          return .requestJSONEncodable(BaseRequestModel(request: request))
+        case .postRecord(let request):          return .requestJSONEncodable(request)
         }
     }
 }

--- a/POME/Data/Service/Record/RecordService.swift
+++ b/POME/Data/Service/Record/RecordService.swift
@@ -26,7 +26,7 @@ extension RecordService{
         }
     }
     
-    func generateRecord(request: RecordRegisterRequestModel, completion: @escaping (Result<Int, Error>) -> Void) {
+    func generateRecord(request: RecordRegisterRequestModel, completion: @escaping (NetworkResult<Any>) -> Void) {
         requestNoResultAPI(RecordRouter.postRecord(request: request)){ response in
             completion(response)
         }

--- a/POME/Global/Source/Protocol/ControlIndexPath.swift
+++ b/POME/Global/Source/Protocol/ControlIndexPath.swift
@@ -1,0 +1,12 @@
+//
+//  ControlIndexPath.swift
+//  POME
+//
+//  Created by 박소윤 on 2023/01/30.
+//
+
+import Foundation
+
+protocol ControlIndexPath{
+    var cardIndexBy: (IndexPath) -> Int { get }
+}

--- a/POME/Global/Source/Protocol/ControlIndexPath.swift
+++ b/POME/Global/Source/Protocol/ControlIndexPath.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol ControlIndexPath{
-    var cardIndexBy: (IndexPath) -> Int { get }
+    var dataIndexBy: (IndexPath) -> Int { get }
 }

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -16,11 +16,7 @@ class FriendViewController: BaseTabViewController, ControlIndexPath {
     //MARK: - Property
     var currentFriendIndex: Int = 0{
         willSet(newValue){
-            if(newValue == 0){
-                requestGetAllFriendsRecords()
-                return
-            }
-            requestGetFriendCards()
+            newValue == 0 ? requestGetAllFriendsRecords() : requestGetFriendCards()
         }
     }
     var currentEmotionSelectCardIndex: Int?{
@@ -34,15 +30,16 @@ class FriendViewController: BaseTabViewController, ControlIndexPath {
 
     var friends = [FriendsResponseModel](){
         didSet{
-            isFriendListEmpty()
-            guard let friendsCell = friendView.tableView.cellForRow(at: [0,0]) as? FriendListTableViewCell else { return }
-            friendsCell.collectionView.reloadData()
+            isTableViewEmpty()
+            if let friendsCell = friendView.tableView.cellForRow(at: [0,0]) as? FriendListTableViewCell{
+                friendsCell.collectionView.reloadData()
+            }
         }
     }
 
     var records = [RecordResponseModel](){
         didSet{
-            //TODO: - EMPTY인 경우 View 처리
+            isTableViewEmpty()
             friendView.tableView.reloadData()
         }
     }
@@ -77,8 +74,6 @@ class FriendViewController: BaseTabViewController, ControlIndexPath {
             $0.top.equalToSuperview().offset(Offset.VIEW_CONTROLLER_TOP)
             $0.leading.trailing.bottom.equalToSuperview()
         }
-        
-        isFriendListEmpty()
     }
     
     override func initialize() {
@@ -93,23 +88,13 @@ class FriendViewController: BaseTabViewController, ControlIndexPath {
     
     //MARK: - Method
     
-    private func isFriendListEmpty(){
-        
+    private func isTableViewEmpty(){
         if(friends.isEmpty){
-            
-            emptyFriendView = FriendTableEmptyView()
-            guard let emptyFriendView = emptyFriendView else { return }
-
-            self.view.addSubview(emptyFriendView)
-            emptyFriendView.snp.makeConstraints{
-                $0.top.equalToSuperview().offset(178)
-                $0.leading.trailing.equalToSuperview()
-                $0.bottom.equalTo(self.view.safeAreaLayoutGuide)
-            }
+            friendView.emptyViewWillShow(case: .nofriend)
+        }else if(records.isEmpty){
+            friendView.emptyViewWillShow(case: .noRecord)
         }else{
-            guard let emptyFriendView = emptyFriendView else { return }
-            emptyFriendView.removeFromSuperview()
-            self.emptyFriendView = nil
+            friendView.emptyViewWillHide()
         }
     }
 }

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -7,10 +7,6 @@
 
 import UIKit
 
-protocol ControlIndexPath{
-    var cardIndexBy: (IndexPath) -> Int { get }
-}
-
 class FriendViewController: BaseTabViewController, ControlIndexPath {
 
     var cardIndexBy: (IndexPath) -> Int = { indexPath in

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class FriendViewController: BaseTabViewController, ControlIndexPath {
 
-    var cardIndexBy: (IndexPath) -> Int = { indexPath in
+    var dataIndexBy: (IndexPath) -> Int = { indexPath in
         return indexPath.row - 1
     }
     
@@ -42,6 +42,7 @@ class FriendViewController: BaseTabViewController, ControlIndexPath {
 
     var records = [RecordResponseModel](){
         didSet{
+            //TODO: - EMPTY인 경우 View 처리
             friendView.tableView.reloadData()
         }
     }
@@ -143,6 +144,7 @@ extension FriendViewController{
                                              pageable: PageableModel(page: 0, size: 10)){ result in
             switch result{
             case .success(let data):
+                print("LOG: success requestGetFriendCards", data)
                 self.records = data
                 break
             default:
@@ -187,16 +189,15 @@ extension FriendViewController: UICollectionViewDelegate, UICollectionViewDataSo
     
             return cell
         }else{
-            
-            //TODO: 친구 데이터 바인딩
-            
+    
             let cell = collectionView.dequeueReusableCell(for: indexPath, cellType: FriendCollectionViewCell.self)
             
             if(indexPath.row == 0){ //친구 목록 - 전체인 경우
                 cell.profileImage.image = Image.categoryInactive
                 cell.nameLabel.text = "전체"
             }else{ //친구 목록 - 친구인 경우
-                cell.nameLabel.text = "연지뉘"
+                cell.nameLabel.text = friends[indexPath.row - 1].friendNickName
+                //TODO: - 친구 이미지 바인딩
             }
             
             if(indexPath.row == currentFriendIndex){

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -121,6 +121,16 @@ extension FriendViewController{
     
     private func requestGetAllFriendsRecords(){
         
+        FriendService.shared.getAllFriendsRecord(pageable: PageableModel(page: 0, size: 10)){ response in
+            switch response {
+            case .success(let data):
+                print("LOG: success requestGetAllFriendsRecords", data)
+                self.records = data
+            default:
+                break
+            }
+        }
+        
     }
     
     private func requestGetFriendCards(){

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -120,8 +120,8 @@ extension FriendViewController{
     }
     
     private func requestGetAllFriendsRecords(){
-        
-        FriendService.shared.getAllFriendsRecord(pageable: PageableModel(page: 0, size: 10)){ response in
+        FriendService.shared.getAllFriendsRecord(pageable: PageableModel(page: 0,
+                                                                         size: 10)){ response in
             switch response {
             case .success(let data):
                 print("LOG: success requestGetAllFriendsRecords", data)
@@ -136,7 +136,8 @@ extension FriendViewController{
     private func requestGetFriendCards(){
         let friendId = friends[currentFriendIndex].friendUserId
         FriendService.shared.getFriendRecord(id: friendId,
-                                             pageable: PageableModel(page: 0, size: 10)){ result in
+                                             pageable: PageableModel(page: 0,
+                                                                     size: 10)){ result in
             switch result{
             case .success(let data):
                 print("LOG: success requestGetFriendCards", data)
@@ -178,10 +179,9 @@ extension FriendViewController: UICollectionViewDelegate, UICollectionViewDataSo
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
 
         if(collectionView == emoijiFloatingView?.collectionView){
-            
             let cell = collectionView.dequeueReusableCell(for: indexPath, cellType: EmojiFloatingCollectionViewCell.self)
             cell.emojiImage.image = Reaction(rawValue: indexPath.row)?.defaultImage
-    
+            
             return cell
         }else{
     
@@ -231,7 +231,8 @@ extension FriendViewController: UICollectionViewDelegate, UICollectionViewDataSo
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize{
         if(collectionView == emoijiFloatingView?.collectionView){
-            return CGSize(width: EmojiFloatingCollectionViewCell.cellWidth, height: EmojiFloatingCollectionViewCell.cellWidth)
+            return CGSize(width: EmojiFloatingCollectionViewCell.cellWidth,
+                          height: EmojiFloatingCollectionViewCell.cellWidth)
         }
         return FriendCollectionViewCell.cellSize
     }
@@ -254,7 +255,7 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Frie
         }
         
         let cell = tableView.dequeueReusableCell(for: indexPath, cellType: FriendTableViewCell.self)
-        let cardIndex = indexPath.row - 1
+        let cardIndex = dataIndexBy(indexPath)
         let record = records[cardIndex]
     
         cell.delegate = self
@@ -264,13 +265,14 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Frie
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let vc = FriendDetailViewController(record: records[indexPath.row - 1])
+        let dataIndex = dataIndexBy(indexPath)
+        let vc = FriendDetailViewController(record: records[dataIndex])
         self.navigationController?.pushViewController(vc, animated: true)
     }
     
     func presentEmojiFloatingView(indexPath: IndexPath) {
 
-        self.currentEmotionSelectCardIndex = indexPath.row - 1
+        self.currentEmotionSelectCardIndex = dataIndexBy(indexPath)
         
         emoijiFloatingView = EmojiFloatingView()
         
@@ -301,6 +303,7 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Frie
         }
     }
     
+    //TODO: - 친구 리액션 바텀시트 데이터 바인딩
     func presentReactionSheet(indexPath: IndexPath) {
         _ = FriendReactionSheetViewController().loadAndShowBottomSheet(in: self)
     }

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -303,9 +303,9 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Frie
         }
     }
     
-    //TODO: - 친구 리액션 바텀시트 데이터 바인딩
     func presentReactionSheet(indexPath: IndexPath) {
-        _ = FriendReactionSheetViewController().loadAndShowBottomSheet(in: self)
+        let data = records[dataIndexBy(indexPath)].friendReactions
+        _ = FriendReactionSheetViewController(reactions: data).loadAndShowBottomSheet(in: self)
     }
     
     func presentEtcActionSheet(indexPath: IndexPath) {

--- a/POME/Presentation/ViewControllers/Record/RecordViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/RecordViewController.swift
@@ -221,16 +221,13 @@ extension RecordViewController {
         GoalCategoryService.shared.getGoalCategory { result in
             switch result {
                 case .success(let data):
-                    if data.success! {
-                        print("goal categories 조회:", data.data)
-                        self.categories = data.data ?? []
-                        self.recordView.recordTableView.reloadData()
-                    }
-                
-                    break
+                print("goal categories 조회:", data)
+                self.categories = data
+                self.recordView.recordTableView.reloadData()
+                break
                 case .failure(let err):
-                    print(err.localizedDescription)
-                    break
+                print(err?.localizedDescription)
+                break
             default:
                 break
             }

--- a/POME/Presentation/ViewControllers/Record/Register/CategorySelectSheetViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/CategorySelectSheetViewController.swift
@@ -13,14 +13,14 @@ class CategorySelectSheetViewController: BaseSheetViewController {
     
     var completion: ((Int) -> ())!
     
-    private let goals: [GoalCategoryResponseModel]
+    private let goals: [GoalResponseModel]
     private let mainView = CategorySelectSheetView().then{
         $0.exitButton.addTarget(self, action: #selector(exitButtonDidClicked), for: .touchUpInside)
     }
     
     //MARK: - LifeCycle
     
-    init(data goals: [GoalCategoryResponseModel]){
+    init(data goals: [GoalResponseModel]){
         self.goals = goals
         super.init(type: .category)
     }
@@ -61,7 +61,7 @@ extension CategorySelectSheetViewController: UITableViewDelegate, UITableViewDat
         
         guard let cell = tableView.dequeueReusableCell(withIdentifier: RecordCategoryTableViewCell.cellIdentifier, for: indexPath) as? RecordCategoryTableViewCell else { return UITableViewCell() }
         
-        cell.nameLabel.text = goals[indexPath.row].name
+        cell.nameLabel.text = goals[indexPath.row].goalNameBinding
         
         return cell
     }

--- a/POME/Presentation/ViewControllers/Record/Register/RecordRegisterContentViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/RecordRegisterContentViewController.swift
@@ -10,7 +10,7 @@ import RxSwift
 
 class RecordRegisterContentViewController: BaseViewController {
     
-    var goals = [GoalCategoryResponseModel]()
+    var goals = [GoalResponseModel]()
     
     private let mainView = RecordRegisterContentView()
     private let viewModel = RecordRegisterContentViewModel(createRecordUseCase: DefaultCreateRecordUseCase())
@@ -118,7 +118,7 @@ class RecordRegisterContentViewController: BaseViewController {
         sheet.completion = { selectIndex in
             let goal = self.goals[selectIndex]
             self.recordManager.goalId =  goal.id//TODO: - GOAL id값으로 넣어주기
-            self.mainView.goalField.infoTextField.text = goal.name
+            self.mainView.goalField.infoTextField.text = goal.goalNameBinding
             self.mainView.goalField.infoTextField.sendActions(for: .valueChanged)
         }
     }
@@ -209,11 +209,11 @@ extension RecordRegisterContentViewController: UITextViewDelegate{
 //MARK: - API
 extension RecordRegisterContentViewController{
     private func requestGetGoals(){
-        GoalCategoryService.shared.getGoalCategory{ result in
+        GoalServcie.shared.getUserGoals{ result in
             switch result{
             case .success(let data):
-                print("LOG: success requestGetGoals", data)
-                self.goals = data
+                print("LOG: success requestGetGoals", data.content)
+                self.goals = data.content
                 break
             default:
                 print(result)

--- a/POME/Presentation/ViewControllers/Record/Register/RecordRegisterContentViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/RecordRegisterContentViewController.swift
@@ -212,10 +212,8 @@ extension RecordRegisterContentViewController{
         GoalCategoryService.shared.getGoalCategory{ result in
             switch result{
             case .success(let data):
-                if let data = data.data{
-                    print("LOG: requestGetGoals", data)
-                    self.goals = data
-                }
+                print("LOG: success requestGetGoals", data)
+                self.goals = data
                 break
             default:
                 print(result)

--- a/POME/Presentation/ViewControllers/Record/Register/RecordRegisterEmotionSelectViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/RecordRegisterEmotionSelectViewController.swift
@@ -129,13 +129,17 @@ extension RecordRegisterEmotionSelectViewController{
                                                  useDate: recordManager.consumeDate,
                                                  useComment: recordManager.detail)
         
+        print(request)
+        
         RecordService.shared.generateRecord(request: request){ result in
             switch result{
             case .success:
+                print("LOG: success requestGenerateRecord")
                 let vc = RegisterSuccessViewController(type: .consume)
                 self.navigationController?.pushViewController(vc, animated: true)
                 break
             default:
+                print(result)
                 break
             }
         }

--- a/POME/Presentation/Views/Friend/FriendDetailView.swift
+++ b/POME/Presentation/Views/Friend/FriendDetailView.swift
@@ -112,7 +112,7 @@ class FriendDetailView: BaseView {
         secondEmotionTag.setTagInfo(when: .second, state: record.secondEmotionBinding)
         myReactionBtn.setImage(record.myReactionBinding, for: .normal)
         
-        record.othersReactionCount == 0 ? setOthersReactionEmpty() : setOthersReaction(thumbnail: record.othersThumbnailReaction, count: record.othersReactionCount)
+        record.othersReactionCountBinding == 0 ? setOthersReactionEmpty() : setOthersReaction(thumbnail: record.othersThumbnailReactionBinding, count: record.othersReactionCountBinding)
     }
     
     func setOthersReactionEmpty(){

--- a/POME/Presentation/Views/Friend/FriendReactionSheetView.swift
+++ b/POME/Presentation/Views/Friend/FriendReactionSheetView.swift
@@ -36,7 +36,7 @@ class FriendReactionSheetView: BaseView {
         $0.textColor = Color.body
     }
     
-    let friendEmotionCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init()).then{
+    let friendReactionCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init()).then{
         
         let flowLayout = UICollectionViewFlowLayout().then{
             $0.itemSize = CGSize(width: FriendReactionCollectionViewCell.cellWidth, height: FriendReactionCollectionViewCell.cellWidth)
@@ -63,7 +63,7 @@ class FriendReactionSheetView: BaseView {
         self.addSubview(emotionCollectionView)
         self.addSubview(separatorLine)
         self.addSubview(countView)
-        self.addSubview(friendEmotionCollectionView)
+        self.addSubview(friendReactionCollectionView)
         
         countView.addSubview(countLabel)
     }
@@ -94,7 +94,7 @@ class FriendReactionSheetView: BaseView {
             $0.leading.equalToSuperview().offset(20)
         }
         
-        friendEmotionCollectionView.snp.makeConstraints{
+        friendReactionCollectionView.snp.makeConstraints{
             $0.top.equalTo(countView.snp.bottom)
             $0.leading.equalToSuperview().offset(20)
             $0.trailing.equalToSuperview().offset(-20)

--- a/POME/Presentation/Views/Friend/FriendTableEmptyView.swift
+++ b/POME/Presentation/Views/Friend/FriendTableEmptyView.swift
@@ -9,6 +9,11 @@ import UIKit
 
 class FriendTableEmptyView: BaseView {
     
+    enum EmptyViewInfo: String{
+        case nofriend = "아직 추가한 친구가 없어요"
+        case noRecord = "기록한 씀씀이가 없어요"
+    }
+    
     let stackView = UIStackView().then{
         $0.spacing = 12
         $0.axis = .vertical
@@ -20,9 +25,8 @@ class FriendTableEmptyView: BaseView {
     }
     
     let emptyLabel = UILabel().then{
-        $0.text = "아직 추가한 친구가 없어요"
         $0.textColor = Color.grey5
-        $0.font = UIFont.autoPretendard(type: .m_14)
+        $0.setTypoStyleWithSingleLine(typoStyle: .subtitle2)
     }
     
     override init(frame: CGRect) {

--- a/POME/Presentation/Views/Friend/FriendView.swift
+++ b/POME/Presentation/Views/Friend/FriendView.swift
@@ -10,9 +10,13 @@ import UIKit
 
 class FriendView: BaseView{
     
+    let emptyView = FriendTableEmptyView()
+    
     let tableView = UITableView().then{
         $0.showsVerticalScrollIndicator = false
         $0.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 74, right: 0)
+        
+        $0.backgroundView = FriendTableEmptyView()
         
         $0.register(FriendListTableViewCell.self, forCellReuseIdentifier: FriendListTableViewCell.cellIdentifier)
         $0.register(FriendTableViewCell.self, forCellReuseIdentifier: FriendTableViewCell.cellIdentifier)
@@ -20,12 +24,27 @@ class FriendView: BaseView{
     
     override func hierarchy() {
         self.addSubview(tableView)
+        tableView.backgroundView = emptyView
     }
     
     override func layout() {
+        
         tableView.snp.makeConstraints{
             $0.top.leading.trailing.bottom.equalToSuperview()
         }
+        
+        tableView.backgroundView?.snp.makeConstraints{
+            $0.centerY.centerX.equalToSuperview()
+        }
+    }
+    
+    func emptyViewWillShow(case type: FriendTableEmptyView.EmptyViewInfo){
+        (tableView.backgroundView as? FriendTableEmptyView)?.emptyLabel.text = type.rawValue
+        tableView.backgroundView?.isHidden = false
+    }
+    
+    func emptyViewWillHide(){
+        tableView.backgroundView?.isHidden = true
     }
 }
 


### PR DESCRIPTION
## What is this PR? 🔍
기록 생성 API 연결 및 친구탭 점검

## Key Changes 🔑
1. NetworkResult invalidSuccess
   - invalidSuccess 케이스에 대해서 errorCode만 제공했었는데, 어떤 오류인지 파악이 안돼서 메시지까지 전달되도록 수정했습니다. 

2. PageableResponseModel 추가
   - 일부 API에선는 data에 응답 데이터를 바로 전달하는 것이 아닌, content로 쌓여져 전달오길래(아마 Pageable 관련한 경우에 한해서) PageableResponseModel 추가했습니다. 

3. 기록 생성 API 연결
   - 목표 카테고리 관련해 이슈가 있었는데, 프론트에서는 목표 카테고리 자체는 사용할 일 없을 것 같네요

4. 친구탭
   - 전체 친구에 대한 기록 조회
   - 친구들 감정 바텀시트 연결

## To Reviewers 📢
- 풀 받고 사용해주세요


## Related Issues ⛱
#131 #140 #143