### PR TITLE
Fix/#131: FriendReactionResponseModel 프로퍼티 네이밍 변경

### DIFF
--- a/POME/Data/Model/Record/RecordResponseModel.swift
+++ b/POME/Data/Model/Record/RecordResponseModel.swift
@@ -24,9 +24,9 @@ struct EmotionResponseModel: Decodable{
     let friendEmotions: [FriendReactionResponseModel]
 }
 
-struct FriendReactionResponseModel: Decodable{ //TODO: 서버 API 수정되면 타입/이름 확인하기
-    let id: Int
-    let name: String
+struct FriendReactionResponseModel: Decodable{
+    let emotionId: Int
+    let nickname: String
 }
 
 extension RecordResponseModel{
@@ -67,7 +67,7 @@ extension RecordResponseModel{
     }
     
     var othersThumbnailReactionBinding: Reaction{
-        Reaction(rawValue: self.emotionResponse.friendEmotions.first!.id) ?? .happy
+        Reaction(rawValue: self.emotionResponse.friendEmotions.first!.emotionId) ?? .happy
     }
     
     var othersReactionCountBinding: Int{

--- a/POME/Presentation/ViewControllers/Friend/FriendReactionSheetViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendReactionSheetViewController.swift
@@ -58,7 +58,7 @@ class FriendReactionSheetViewController: BaseSheetViewController {
             filterReactions = reactions
             return
         }
-        filterReactions = reactions.filter{ $0.id == id - 1 }
+        filterReactions = reactions.filter{ $0.emotionId == id - 1 }
     }
 }
 
@@ -79,8 +79,8 @@ extension FriendReactionSheetViewController: UICollectionViewDelegate, UICollect
         }else{
             let cell = collectionView.dequeueReusableCell(for: indexPath, cellType: FriendReactionCollectionViewCell.self)
             let data = filterReactions[indexPath.row]
-            cell.reactionImage.image = Reaction(rawValue: data.id)?.defaultImage
-            cell.nicknameLabel.text = data.name
+            cell.reactionImage.image = Reaction(rawValue: data.emotionId)?.defaultImage
+            cell.nicknameLabel.text = data.nickname
     
             return cell
         }


### PR DESCRIPTION
## What is this PR? 🔍
FriendReactionResponseModel 프로퍼티 네이밍 변경

## Key Changes 🔑
1. RecordResponseModel의 하위 Modeld인 FriendReactionResponseModel가 서버에서 친구 닉네임 정보가 추가가 완료되어 프로퍼티 네이밍이 확정됐습니다!

## Related Issues ⛱
#131