### PR TITLE
목표 API 연결

### DIFF
--- a/POME.xcodeproj/project.pbxproj
+++ b/POME.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		232F3FD6292D5E0A009F2EE5 /* AlarmSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 232F3FD5292D5E0A009F2EE5 /* AlarmSettingViewController.swift */; };
 		232F3FD9292D5E40009F2EE5 /* AlarmSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 232F3FD8292D5E40009F2EE5 /* AlarmSettingView.swift */; };
 		232FD9D2293436950072E9D5 /* MypageFriendViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 232FD9D1293436950072E9D5 /* MypageFriendViewController.swift */; };
+		2338F4AC2989079400F37EA1 /* TapGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2338F4AB2989079400F37EA1 /* TapGesture.swift */; };
 		2339649B292EC71D000F6BAC /* FinishGoalTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2339649A292EC71D000F6BAC /* FinishGoalTableViewCell.swift */; };
 		2339649D292EC9A8000F6BAC /* AllRecordsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2339649C292EC9A8000F6BAC /* AllRecordsViewController.swift */; };
 		2339649F292EC9F7000F6BAC /* AllRecordsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2339649E292EC9F7000F6BAC /* AllRecordsView.swift */; };
@@ -245,6 +246,7 @@
 		232F3FD5292D5E0A009F2EE5 /* AlarmSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmSettingViewController.swift; sourceTree = "<group>"; };
 		232F3FD8292D5E40009F2EE5 /* AlarmSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlarmSettingView.swift; sourceTree = "<group>"; };
 		232FD9D1293436950072E9D5 /* MypageFriendViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MypageFriendViewController.swift; sourceTree = "<group>"; };
+		2338F4AB2989079400F37EA1 /* TapGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapGesture.swift; sourceTree = "<group>"; };
 		2339649A292EC71D000F6BAC /* FinishGoalTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishGoalTableViewCell.swift; sourceTree = "<group>"; };
 		2339649C292EC9A8000F6BAC /* AllRecordsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllRecordsViewController.swift; sourceTree = "<group>"; };
 		2339649E292EC9F7000F6BAC /* AllRecordsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllRecordsView.swift; sourceTree = "<group>"; };
@@ -513,6 +515,14 @@
 				232F3FD8292D5E40009F2EE5 /* AlarmSettingView.swift */,
 			);
 			path = Setting;
+			sourceTree = "<group>";
+		};
+		2338F4AA2989077F00F37EA1 /* TapGestures */ = {
+			isa = PBXGroup;
+			children = (
+				2338F4AB2989079400F37EA1 /* TapGesture.swift */,
+			);
+			path = TapGestures;
 			sourceTree = "<group>";
 		};
 		233964A2292ED5BB000F6BAC /* Goal */ = {
@@ -784,6 +794,7 @@
 		5724EC19291012DA00DC529B /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				2338F4AA2989077F00F37EA1 /* TapGestures */,
 				5724EC85291B4C9200DC529B /* Const.swift */,
 				EE98F0C72980DFD0007BFCCD /* UserManager */,
 				5724EC732919220800DC529B /* Base */,
@@ -1786,6 +1797,7 @@
 				5724EBEB29100C8500DC529B /* BaseViewController.swift in Sources */,
 				5724EC512917680A00DC529B /* TabBarController.swift in Sources */,
 				57CCA797292B7A1E007E22D1 /* TagStyle.swift in Sources */,
+				2338F4AC2989079400F37EA1 /* TapGesture.swift in Sources */,
 				57CCA78D292B0AB4007E22D1 /* GoalTagCollectionViewCell.swift in Sources */,
 				57CCA77F29290212007E22D1 /* FriendReactionCollectionViewCell.swift in Sources */,
 				EE98F0C92980E126007BFCCD /* UserDefault.swift in Sources */,

--- a/POME/Data/Model/Goal/GoalResponseModel.swift
+++ b/POME/Data/Model/Goal/GoalResponseModel.swift
@@ -11,7 +11,6 @@ struct GoalResponseModel: Decodable {
     let endDate: String
     let goalCategoryResponse: GoalCategoryResponseModel
     let id: Int
-    let isEnd: Bool
     let isPublic: Bool
     let nickname: String
     let oneLineMind: String

--- a/POME/Data/Service/Goal/GoalServcie.swift
+++ b/POME/Data/Service/Goal/GoalServcie.swift
@@ -33,8 +33,8 @@ extension GoalServcie{
         }
     }
     
-    func deleteGoal(id: Int, completion: @escaping (Result<Int, Error>) -> Void) {
-        requestNoResultAPI(GoalRouter.deleteGoal(id: id)){ response in
+    func deleteGoal(id: Int, completion: @escaping (Result<BaseResponseModel<Bool>, Error>) -> Void) {
+        requestDecoded(GoalRouter.deleteGoal(id: id)) { response in
             completion(response)
         }
     }

--- a/POME/Global/Source/TapGestures/TapGesture.swift
+++ b/POME/Global/Source/TapGestures/TapGesture.swift
@@ -1,0 +1,16 @@
+//
+//  TapGesture.swift
+//  POME
+//
+//  Created by gomin on 2023/01/31.
+//
+
+import Foundation
+
+class GoalTapGesture: UITapGestureRecognizer {
+    var data: GoalResponseModel?
+}
+
+class FriendTapGesture: UITapGestureRecognizer {
+    var data: FriendsResponseModel?
+}

--- a/POME/Presentation/Cells/MyPage/MypageGoalsTableViewCell.swift
+++ b/POME/Presentation/Cells/MyPage/MypageGoalsTableViewCell.swift
@@ -83,3 +83,20 @@ class MypageGoalsTableViewCell: BaseTableViewCell {
         }
     }
 }
+//MARK: - API
+// TODO: 완료한 목표 보관함
+//extension MypageGoalsTableViewCell {
+//    public func getGoalCounts(){
+//        GoalServcie.shared.getUserGoals{ result in
+//            switch result{
+//            case .success(let data):
+//                self.subTitleLabel.text = "다시 보고 싶은 지난 목표가 \(data.content.count)건 있어요"
+//
+//                break
+//            default:
+//                print(result)
+//                break
+//            }
+//        }
+//    }
+//}

--- a/POME/Presentation/Cells/Record/Goal/GoalTableViewCell.swift
+++ b/POME/Presentation/Cells/Record/Goal/GoalTableViewCell.swift
@@ -128,9 +128,8 @@ class GoalTableViewCell: BaseTableViewCell {
     // After API
     func setUpData(_ data: GoalResponseModel) {
         let startDate = data.startDate
-        let endDate = data.endDate
+        let endDateStr = data.endDate
         let goalId = data.id
-        let isEnd = data.isEnd
         let isPublic = data.isPublic
         let nickname = data.nickname
         let oneLineMind = data.oneLineMind
@@ -144,11 +143,30 @@ class GoalTableViewCell: BaseTableViewCell {
         let result = numberFormatter.string(from: NSNumber(value: price)) ?? ""
         goalConsumeLabel.text = "· " + result + "원"
 
-        goalIsPublicLabel = isPublic ? LockTagLabel.generateOpenTag() : LockTagLabel.generateUnopenTag()
+        if isPublic {
+            goalIsPublicLabel.setPublicState()
+        } else {
+            goalIsPublicLabel.setLockState()
+        }
 
-        // TODO: startDate와 endDate 비교해 시간 계산
-        // 끝나면 END
+        // 현재 시간과 endDate 비교해 시간 계산
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy.MM.dd"
+        let date = Date()
+        let nowDateStr = formatter.string(from: date)
+        let nowDate = formatter.date(from: nowDateStr)
         
+        let endDate = formatter.date(from: endDateStr)
+        let diffBetweenDates = endDate!.timeIntervalSince(nowDate!)
+        let diff = Int(diffBetweenDates / (60 * 60 * 24))
+        
+        if diff > 0 {
+            goalRemainDateLabel.setRemainDate(date: String(diff))
+        } else {
+            goalRemainDateLabel.setEnd()
+        }
+        
+        // TODO: 사용 금액으로 ProgressBar 만들기
 
 
     }

--- a/POME/Presentation/ViewControllers/MyPage/MypageFriendViewController.swift
+++ b/POME/Presentation/ViewControllers/MyPage/MypageFriendViewController.swift
@@ -127,7 +127,3 @@ extension MypageFriendViewController {
         }
     }
 }
-// MARK: - Tap Gesture
-class FriendTapGesture: UITapGestureRecognizer {
-    var data: FriendsResponseModel?
-}

--- a/POME/Presentation/ViewControllers/Record/RecordViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/RecordViewController.swift
@@ -60,6 +60,10 @@ class RecordViewController: BaseTabViewController {
         self.present(sheet, animated: true, completion: nil)
          */
     }
+    @objc func finishGoalButtonDidTap() {
+        let vc = AllRecordsViewController()
+        self.navigationController?.pushViewController(vc, animated: true)
+    }
     @objc func cannotAddGoalButtonDidTap() {
         //TODO: 목표 등록/개수 제한 팝업 코드 분리
         let vc = GoalDateViewController()
@@ -128,7 +132,7 @@ extension RecordViewController: UICollectionViewDelegate, UICollectionViewDataSo
         cell.goalCategoryLabel.text = categories[itemIdx].name
         
         if itemIdx == self.categorySelectedIdx {cell.setSelectState()}
-        else if goalContent[itemIdx].isEnd {cell.setInactivateState()} // 종료된 목표일 시
+        else if isGoalEnd(goalContent[itemIdx]) {cell.setInactivateState()} // 종료된 목표일 시
         else {cell.setUnselectState()}
         
         return cell
@@ -138,7 +142,7 @@ extension RecordViewController: UICollectionViewDelegate, UICollectionViewDataSo
         let itemIdx = indexPath.row
         self.categorySelectedIdx = itemIdx
         
-        if goalContent[itemIdx].isEnd {self.showGoalFinishWarning()}
+        if isGoalEnd(goalContent[itemIdx]) {self.showGoalFinishWarning()}
         self.recordView.recordTableView.reloadData()
         
         return true
@@ -187,13 +191,12 @@ extension RecordViewController: UITableViewDelegate, UITableViewDataSource {
                 return cell
             }
             
-            /* 셀 작업 위해 임시로 주석 처리
             // MARK: 목표 종료 셀
-            if goalContent[self.categorySelectedIdx].isEnd {
+            if isGoalEnd(goalContent[self.categorySelectedIdx]) {
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: "FinishGoalTableViewCell", for: indexPath) as? FinishGoalTableViewCell else { return UITableViewCell() }
+                cell.finishGoalButton.addTarget(self, action: #selector(finishGoalButtonDidTap), for: .touchUpInside)
                 return cell
             }
-             */
             
             return cell
         case 2:
@@ -247,6 +250,21 @@ extension RecordViewController {
                 print(result)
                 break
             }
+        }
+    }
+    private func isGoalEnd(_ data: GoalResponseModel) -> Bool {
+        let endDate = data.endDate
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy.MM.dd"
+        let convertDate = dateFormatter.date(from: endDate)
+        
+        // 종료 날짜가 오늘보다 이전인 지 확인
+        let result: ComparisonResult = Date().compare(convertDate ?? .now)
+        if result == .orderedDescending {
+            return true
+        } else {
+            return false
         }
     }
 }

--- a/POME/Presentation/ViewControllers/Record/RecordViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/RecordViewController.swift
@@ -51,20 +51,20 @@ class RecordViewController: BaseTabViewController {
         self.navigationController?.pushViewController(NotificationViewController(), animated: true)
     }
     @objc func writeButtonDidTap() {
-        //TODO: 소비 기록 등록/소비 등록 제한 코드 분리
-        let vc = RecordRegisterContentViewController()
-        self.navigationController?.pushViewController(vc, animated: true)
-        /*
-        let sheet = RecordBottomSheetViewController(Image.flagMint, "지금은 씀씀이를 기록할 수 없어요", "나만의 소비 목표를 설정하고\n기록을 시작해보세요!")
-        sheet.loadViewIfNeeded()
-        self.present(sheet, animated: true, completion: nil)
-         */
+        if self.goalContent.isEmpty {
+            let sheet = RecordBottomSheetViewController(Image.flagMint, "지금은 씀씀이를 기록할 수 없어요", "나만의 소비 목표를 설정하고\n기록을 시작해보세요!")
+            sheet.loadViewIfNeeded()
+            self.present(sheet, animated: true, completion: nil)
+        } else {
+            let vc = RecordRegisterContentViewController()
+            self.navigationController?.pushViewController(vc, animated: true)
+        }
     }
     @objc func finishGoalButtonDidTap() {
         let vc = AllRecordsViewController()
         self.navigationController?.pushViewController(vc, animated: true)
     }
-    @objc func cannotAddGoalButtonDidTap() {
+    @objc func addGoalButtonDidTap() {
         //TODO: 목표 등록/개수 제한 팝업 코드 분리
         let vc = GoalDateViewController()
         self.navigationController?.pushViewController(vc, animated: true)
@@ -174,7 +174,7 @@ extension RecordViewController: UITableViewDelegate, UITableViewDataSource {
             cell.goalCollectionView.reloadData()
             
             // Add Goal
-            cell.goalPlusButton.addTarget(self, action: #selector(cannotAddGoalButtonDidTap), for: .touchUpInside)
+            cell.goalPlusButton.addTarget(self, action: #selector(addGoalButtonDidTap), for: .touchUpInside)
             
             return cell
         case 1:
@@ -193,7 +193,7 @@ extension RecordViewController: UITableViewDelegate, UITableViewDataSource {
             // MARK: 목표가 존재하지 않을 때
             if self.categories.count == 0 {
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: "EmptyGoalTableViewCell", for: indexPath) as? EmptyGoalTableViewCell else { return UITableViewCell() }
-                cell.makeGoalButton.addTarget(self, action: #selector(writeButtonDidTap), for: .touchUpInside)
+                cell.makeGoalButton.addTarget(self, action: #selector(addGoalButtonDidTap), for: .touchUpInside)
                 return cell
             }
             


### PR DESCRIPTION
## What is this PR? 🔍
목표 API 연결
## Key Changes 🔑
1. 날짜 연산 후, 기간 지난 목표 분리
2. 공개/미공개 태그 적용 (generate 아직 삭제 안 함)
3. 디데이 태그 적용 (generate 아직 삭제 안 함)
4. 목표 삭제하기 API 연결
5. TapGesture 파일 추가
     - sender로 데이터 전송
6. 소비 기록/ 제한 코드 분리

## To Reviewers 📢
TapGesture 파일 추가했습니다. 
날짜 연산에 관해서는 임시로 제가 구현했습니다.

## Related Issues ⛱
목표 완료 기준이 모호합니다.
목표 조회 시, 사용금액 응답값 수정사항이 반영된 후 추가작업 하겠습니다.
기한이 지난 목표들은 응답 올 때 맨 뒤로 정렬되어야합니다.