### PR TITLE
Refactor/#131: PageableResponseModel + NetworkResult 활용 

### DIFF
--- a/POME.xcodeproj/project.pbxproj
+++ b/POME.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		96CC3BB984ACAEF3CFEE1D59 /* Pods_POMETests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BBADA360F64B55B3A1453232 /* Pods_POMETests.framework */; };
 		A327F9890E2682D681FA0D75 /* Pods_POME_POMEUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47547FEA22B2A0C8326E18A9 /* Pods_POME_POMEUITests.framework */; };
 		EE44601F2983D1EB00B1A311 /* GoalCategoryResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE44601E2983D1EB00B1A311 /* GoalCategoryResponseModel.swift */; };
+		EE7C9FF4298A510300D2F238 /* PomeDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7C9FF3298A510300D2F238 /* PomeDateFormatter.swift */; };
 		EE9505D1298799DB00077B28 /* PageableResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE9505D0298799DB00077B28 /* PageableResponseModel.swift */; };
 		EE9505D329879C0C00077B28 /* ControlIndexPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE9505D229879C0C00077B28 /* ControlIndexPath.swift */; };
 		EE98F0BE2980DEE7007BFCCD /* HTTPMethodURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE98F0BD2980DEE7007BFCCD /* HTTPMethodURL.swift */; };
@@ -409,6 +410,7 @@
 		99A020A78BC79702AA87A558 /* Pods-POMETests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-POMETests.debug.xcconfig"; path = "Target Support Files/Pods-POMETests/Pods-POMETests.debug.xcconfig"; sourceTree = "<group>"; };
 		BBADA360F64B55B3A1453232 /* Pods_POMETests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_POMETests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EE44601E2983D1EB00B1A311 /* GoalCategoryResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalCategoryResponseModel.swift; sourceTree = "<group>"; };
+		EE7C9FF3298A510300D2F238 /* PomeDateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomeDateFormatter.swift; sourceTree = "<group>"; };
 		EE9505D0298799DB00077B28 /* PageableResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageableResponseModel.swift; sourceTree = "<group>"; };
 		EE9505D229879C0C00077B28 /* ControlIndexPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlIndexPath.swift; sourceTree = "<group>"; };
 		EE98F0BD2980DEE7007BFCCD /* HTTPMethodURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethodURL.swift; sourceTree = "<group>"; };
@@ -794,8 +796,8 @@
 		5724EC19291012DA00DC529B /* Source */ = {
 			isa = PBXGroup;
 			children = (
-				2338F4AA2989077F00F37EA1 /* TapGestures */,
 				5724EC85291B4C9200DC529B /* Const.swift */,
+				2338F4AA2989077F00F37EA1 /* TapGestures */,
 				EE98F0C72980DFD0007BFCCD /* UserManager */,
 				5724EC732919220800DC529B /* Base */,
 				57543B762951BE8600A409E3 /* Calendar */,
@@ -805,6 +807,7 @@
 				57CCA7CA292EF937007E22D1 /* Register */,
 				57CCA77229286E9F007E22D1 /* Sheet */,
 				57B16851295941BD00639A15 /* Toast */,
+				EE7C9FF3298A510300D2F238 /* PomeDateFormatter.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -1903,6 +1906,7 @@
 				57CCA77429286EC2007E22D1 /* SheetInfo.swift in Sources */,
 				5724EC4F29168A8800DC529B /* BaseView.swift in Sources */,
 				57B32C3D292466010018C0CB /* TypoStyle.swift in Sources */,
+				EE7C9FF4298A510300D2F238 /* PomeDateFormatter.swift in Sources */,
 				57CCA75F2925AF2C007E22D1 /* FriendDetailView.swift in Sources */,
 				23F364D1291B793B009232B4 /* RegisterViewControllerExtension.swift in Sources */,
 				23ADE499292D405D003002D9 /* MypageGoalsTableViewCell.swift in Sources */,

--- a/POME/Data/Model/PageableModel.swift
+++ b/POME/Data/Model/PageableModel.swift
@@ -9,20 +9,6 @@ import Foundation
 
 struct PageableModel: Encodable{
     let page: Int
-    let size: Int
+    let size: Int = Const.requestPagingSize
     let sort = ["string"]
-}
-
-
-protocol ConvertDictionary{
-}
-
-extension ConvertDictionary where Self: Encodable{
-    /*
-    var dictionary: [String : Any] {
-        let data = try JSONEncoder().encode(self)
-        guard let dictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String:Any] else { throw NSError() }
-        return dictionary
-    }
-     */
 }

--- a/POME/Data/Model/PageableResponseModel.swift
+++ b/POME/Data/Model/PageableResponseModel.swift
@@ -8,5 +8,7 @@
 import Foundation
 
 struct PageableResponseModel<T: Decodable>: Decodable{
-    let content: T
+    let content: [T]
+    let empty: Bool
 }
+

--- a/POME/Data/Model/Record/RecordResponseModel.swift
+++ b/POME/Data/Model/Record/RecordResponseModel.swift
@@ -30,38 +30,6 @@ struct FriendReactionResponseModel: Decodable{
     let nickname: String
 }
 
-// 목표에 기록된 씀씀이 조회
-struct RecordOfGoalResponseModel: Decodable {
-    let content: [RecordResponseModel]
-    let pageable: PagingModel
-    let totalPages: Int
-    let totalElements: Int
-    let last: Bool
-    let size: Int
-    let number: Int
-    let sort: SortModel
-    let numberOfElements: Int
-    let first: Bool
-    let empty: Bool
-}
-
-
-struct PagingModel: Decodable {
-    let sort: SortModel
-    let offset: Int
-    let pageNumber: Int
-    let pageSize: Int
-    let paged: Bool
-    let unpaged: Bool
-}
-
-struct SortModel: Decodable {
-    let empty: Bool
-    let sorted: Bool
-    let unsorted: Bool
-}
-
-
 extension RecordResponseModel{
     
     var goalPromiseBinding: String{
@@ -116,7 +84,7 @@ extension RecordResponseModel{
     // "useDate": "2023.02.23"
     private var isTodayWritten: Bool{
         let createTimeReplace = createdAt.replacingOccurrences(of: "-", with: ".")
-        let createTime = createTimeReplace.split(separator: " ")[0]
+        let createTime = createTimeReplace.split(separator: "T")[0]
         return createTime == self.useDate
     }
     

--- a/POME/Data/Service/Goal/GoalServcie.swift
+++ b/POME/Data/Service/Goal/GoalServcie.swift
@@ -39,7 +39,7 @@ extension GoalServcie{
         }
     }
     
-    func getUserGoals(completion: @escaping (NetworkResult<PageableResponseModel<[GoalResponseModel]>>) -> Void) {
+    func getUserGoals(completion: @escaping (NetworkResult<PageableResponseModel<GoalResponseModel>>) -> Void) {
         requestDecoded(GoalRouter.getGoals){ response in
             completion(response)
         }

--- a/POME/Data/Service/Record/RecordRouter.swift
+++ b/POME/Data/Service/Record/RecordRouter.swift
@@ -12,7 +12,7 @@ enum RecordRouter: BaseRouter{
     case patchRecord(id: Int, request: RecordRegisterRequestModel)
     case deleteRecord(id: Int)
     case postRecord(request: RecordRegisterRequestModel)
-    case getRecordsOfGoalByUser(id: Int, page: Int, size: Int)
+    case getRecordsOfGoalByUser(id: Int, pageable: PageableModel)
 }
 
 extension RecordRouter{
@@ -22,7 +22,7 @@ extension RecordRouter{
         case .patchRecord(let id, _):      return HTTPMethodURL.PUT.record + "/\(id)"
         case .deleteRecord(let id):     return HTTPMethodURL.DELETE.record + "/\(id)"
         case .postRecord:               return HTTPMethodURL.POST.record
-        case .getRecordsOfGoalByUser(let id, _, _): return HTTPMethodURL.GET.recordOfGoal + "/\(id)"
+        case .getRecordsOfGoalByUser(let id, _): return HTTPMethodURL.GET.recordOfGoal + "/\(id)"
         }
     }
     
@@ -40,8 +40,8 @@ extension RecordRouter{
         case .patchRecord(_, let request):      return .requestJSONEncodable(request)
         case .deleteRecord:                     return .requestPlain
         case .postRecord(let request):          return .requestJSONEncodable(request)
-        case .getRecordsOfGoalByUser(_, let page, let size):
-            return .requestParameters(parameters: ["page": page, "size": size], encoding: URLEncoding.queryString)
+        case .getRecordsOfGoalByUser(_, let pageable):
+            return .requestJSONEncodable(pageable)
         }
     }
 }

--- a/POME/Data/Service/Record/RecordRouter.swift
+++ b/POME/Data/Service/Record/RecordRouter.swift
@@ -19,10 +19,10 @@ extension RecordRouter{
     
     var path: String {
         switch self {
-        case .patchRecord(let id, _):      return HTTPMethodURL.PUT.record + "/\(id)"
-        case .deleteRecord(let id):     return HTTPMethodURL.DELETE.record + "/\(id)"
-        case .postRecord:               return HTTPMethodURL.POST.record
-        case .getRecordsOfGoalByUser(let id, _): return HTTPMethodURL.GET.recordOfGoal + "/\(id)"
+        case .patchRecord(let id, _):               return HTTPMethodURL.PUT.record + "/\(id)"
+        case .deleteRecord(let id):                 return HTTPMethodURL.DELETE.record + "/\(id)"
+        case .postRecord:                           return HTTPMethodURL.POST.record
+        case .getRecordsOfGoalByUser(let id, _):    return HTTPMethodURL.GET.recordOfGoal + "/\(id)"
         }
     }
     
@@ -37,11 +37,13 @@ extension RecordRouter{
     
     var task: Task {
         switch self{
-        case .patchRecord(_, let request):      return .requestJSONEncodable(request)
-        case .deleteRecord:                     return .requestPlain
-        case .postRecord(let request):          return .requestJSONEncodable(request)
-        case .getRecordsOfGoalByUser(_, let pageable):
-            return .requestJSONEncodable(pageable)
+        case .patchRecord(_, let request):              return .requestJSONEncodable(request)
+        case .deleteRecord:                             return .requestPlain
+        case .postRecord(let request):                  return .requestJSONEncodable(request)
+        case .getRecordsOfGoalByUser(_, let pageable):  return .requestParameters(parameters: ["page" : pageable.page,
+                                                                                               "size" : pageable.size,
+                                                                                               "sort" : pageable.sort],
+                                                                                  encoding: URLEncoding.queryString)
         }
     }
 }

--- a/POME/Data/Service/Record/RecordService.swift
+++ b/POME/Data/Service/Record/RecordService.swift
@@ -32,8 +32,8 @@ extension RecordService{
         }
     }
     
-    func getRecordsOfGoal(id: Int, page: Int, size: Int, completion: @escaping (Result<BaseResponseModel<RecordOfGoalResponseModel>, Error>) -> Void) {
-        requestDecoded(RecordRouter.getRecordsOfGoalByUser(id: id, page: page, size: size)) { response in
+    func getRecordsOfGoal(id: Int, pageable: PageableModel, completion: @escaping (NetworkResult<RecordOfGoalResponseModel>) -> Void) {
+        requestDecoded(RecordRouter.getRecordsOfGoalByUser(id: id, pageable: pageable)) { response in
             completion(response)
         }
     }

--- a/POME/Data/Service/Record/RecordService.swift
+++ b/POME/Data/Service/Record/RecordService.swift
@@ -32,7 +32,7 @@ extension RecordService{
         }
     }
     
-    func getRecordsOfGoal(id: Int, pageable: PageableModel, completion: @escaping (NetworkResult<RecordOfGoalResponseModel>) -> Void) {
+    func getRecordsOfGoal(id: Int, pageable: PageableModel, completion: @escaping (NetworkResult<PageableResponseModel<RecordResponseModel>>) -> Void) {
         requestDecoded(RecordRouter.getRecordsOfGoalByUser(id: id, pageable: pageable)) { response in
             completion(response)
         }

--- a/POME/Global/Source/Const.swift
+++ b/POME/Global/Source/Const.swift
@@ -10,6 +10,7 @@ import UIKit
 
 struct Const{
     static let `default` = -1 //enum 형 등에서 default에 매핑되는 정수 값
+    static let  requestPagingSize = 15
 }
 
 struct Device{

--- a/POME/Global/Source/PomeDateFormatter.swift
+++ b/POME/Global/Source/PomeDateFormatter.swift
@@ -1,0 +1,42 @@
+//
+//  PomeDateFormatter.swift
+//  POME
+//
+//  Created by 박소윤 on 2023/02/01.
+//
+
+import Foundation
+
+struct PomeDateFormatter{
+    
+    static let formatter = DateFormatter().then{
+        $0.dateFormat = "yyyy.MM.dd"
+    }
+    
+    static func getTodayDate() -> String{
+        return formatter.string(from: Date())
+    }
+    
+    static func getDateString(_ date: CalendarSelectDate) -> String{
+        "\(date.year)." + convertIntToFormatterString(date.month) + "." + convertIntToFormatterString(date.date)
+    }
+    
+    static func getRecordDateString(_ date: String) -> String{
+        //'2023.02.23' > '2월 23일'
+        guard let date = PomeDateFormatter.formatter.date(from: date) else {
+            return ""
+        }
+        let formatter = DateFormatter().then{
+            $0.dateFormat = "M월 d일"
+        }
+        return formatter.string(from: date)
+    }
+    
+    static private func convertIntToFormatterString(_ int: Int) -> String{
+        int < 10 ? "0\(int)" : String(int)
+    }
+    
+    static func getDateType(from: String){
+        formatter.date(from: from)
+    }
+}

--- a/POME/Presentation/Cells/Review/ConsumeReviewTableViewCell.swift
+++ b/POME/Presentation/Cells/Review/ConsumeReviewTableViewCell.swift
@@ -9,14 +9,11 @@ import UIKit
 
 class ConsumeReviewTableViewCell: BaseTableViewCell {
     
-    static let cellIdentifier = "ConsumeReviewTableViewCell"
-    
     let shadowView = UIView().then{
         $0.layer.borderWidth = 1
         $0.layer.borderColor = Color.grey2.cgColor
         $0.setShadowStyle(type: .card)
     }
-    
     let mainView = ReviewDetailView().then{
         $0.memoLabel.numberOfLines = 2
     }

--- a/POME/Presentation/ViewControllers/Friend/FriendReactionSheetViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendReactionSheetViewController.swift
@@ -13,6 +13,7 @@ class FriendReactionSheetViewController: BaseSheetViewController {
     var currentReaction: Int = 0
     var filterReactions: [FriendReactionResponseModel]!{
         didSet{
+            mainView.countLabel.text = "전체 \(filterReactions.count)개"
             mainView.friendReactionCollectionView.reloadData()
         }
     }
@@ -23,7 +24,6 @@ class FriendReactionSheetViewController: BaseSheetViewController {
     //MARK: - LifeCycle
     
     init(reactions: [FriendReactionResponseModel]){
-        self.filterReactions = reactions
         self.reactions = reactions
         super.init(type: .friendReaction)
     }
@@ -41,6 +41,9 @@ class FriendReactionSheetViewController: BaseSheetViewController {
         
         mainView.friendReactionCollectionView.delegate = self
         mainView.friendReactionCollectionView.dataSource = self
+        
+        mainView.countLabel.text = "전체 \(reactions.count)개"
+        filterReactions = reactions
     }
     
     override func layout() {
@@ -54,11 +57,7 @@ class FriendReactionSheetViewController: BaseSheetViewController {
     }
     
     private func filterReactionBy(id: Int){
-        if(id == 0){
-            filterReactions = reactions
-            return
-        }
-        filterReactions = reactions.filter{ $0.emotionId == id - 1 }
+        filterReactions = id == 0 ? reactions : reactions.filter{ $0.emotionId == id - 1 }
     }
 }
 
@@ -77,8 +76,10 @@ extension FriendReactionSheetViewController: UICollectionViewDelegate, UICollect
             
             return cell
         }else{
+            
             let cell = collectionView.dequeueReusableCell(for: indexPath, cellType: FriendReactionCollectionViewCell.self)
             let data = filterReactions[indexPath.row]
+            
             cell.reactionImage.image = Reaction(rawValue: data.emotionId)?.defaultImage
             cell.nicknameLabel.text = data.nickname
     

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -95,8 +95,7 @@ class FriendViewController: BaseTabViewController, ControlIndexPath {
 extension FriendViewController{
     
     private func requestGetFriends(){
-        FriendService.shared.getFriends(pageable: PageableModel(page: 1,
-                                                                size: 10)){ result in
+        FriendService.shared.getFriends(pageable: PageableModel(page: 1)){ result in
             switch result{
             case .success(let data):
                     print("LOG: 'success' requestGetFriends", data)
@@ -112,8 +111,7 @@ extension FriendViewController{
     }
     
     private func requestGetAllFriendsRecords(){
-        FriendService.shared.getAllFriendsRecord(pageable: PageableModel(page: 0,
-                                                                         size: 10)){ response in
+        FriendService.shared.getAllFriendsRecord(pageable: PageableModel(page: 0)){ response in
             switch response {
             case .success(let data):
                 print("LOG: success requestGetAllFriendsRecords", data)
@@ -128,8 +126,7 @@ extension FriendViewController{
     private func requestGetFriendCards(){
         let friendId = friends[currentFriendIndex].friendUserId
         FriendService.shared.getFriendRecord(id: friendId,
-                                             pageable: PageableModel(page: 0,
-                                                                     size: 10)){ result in
+                                             pageable: PageableModel(page: 0)){ result in
             switch result{
             case .success(let data):
                 print("LOG: success requestGetFriendCards", data)

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -29,7 +29,6 @@ class FriendViewController: BaseTabViewController, ControlIndexPath {
             }
         }
     }
-
     var records = [RecordResponseModel](){
         didSet{
             isTableViewEmpty()
@@ -265,7 +264,7 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Frie
     }
     
     func presentEmojiFloatingView(indexPath: IndexPath) {
-        print(dataIndexBy(indexPath))
+
         self.currentEmotionSelectCardIndex = dataIndexBy(indexPath)
         
         emoijiFloatingView = EmojiFloatingView()

--- a/POME/Presentation/ViewControllers/MyPage/MypageFriendViewController.swift
+++ b/POME/Presentation/ViewControllers/MyPage/MypageFriendViewController.swift
@@ -91,7 +91,7 @@ extension MypageFriendViewController: UITableViewDelegate, UITableViewDataSource
 extension MypageFriendViewController {
     // 친구 목록 조회
     private func getFriends() {
-        let pageModel = PageableModel(page: 0, size: 1)
+        let pageModel = PageableModel(page: 0)
         FriendService.shared.getFriends(pageable: pageModel) { result in
             switch result {
                 case .success(let data):

--- a/POME/Presentation/ViewControllers/Record/RecordViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/RecordViewController.swift
@@ -286,8 +286,7 @@ extension RecordViewController {
         }
     }
     private func getRecordsOfGoal(id: Int, page: Int, size: Int) {
-        RecordService.shared.getRecordsOfGoal(id: id, pageable: PageableModel(page: page,
-                                                                              size: size)) { result in
+        RecordService.shared.getRecordsOfGoal(id: id, pageable: PageableModel(page: page)) { result in
             switch result{
             case .success(let data):
                 print("LOG: 씀씀이 조회", data.content)

--- a/POME/Presentation/ViewControllers/Record/RecordViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/RecordViewController.swift
@@ -286,15 +286,13 @@ extension RecordViewController {
         }
     }
     private func getRecordsOfGoal(id: Int, page: Int, size: Int) {
-        RecordService.shared.getRecordsOfGoal(id: id, page: page, size: size) { result in
+        RecordService.shared.getRecordsOfGoal(id: id, pageable: PageableModel(page: page,
+                                                                              size: size)) { result in
             switch result{
             case .success(let data):
-                print(data)
-                if data.success! {
-                    print("LOG: 씀씀이 조회", data.data?.content)
-                    self.recordsOfGoal = data.data?.content ?? []
-                    self.recordView.recordTableView.reloadData()
-                }
+                print("LOG: 씀씀이 조회", data.content)
+                self.recordsOfGoal = data.content
+                self.recordView.recordTableView.reloadData()
                 break
             default:
                 print(result)

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -113,8 +113,7 @@ extension ReviewViewController{
     
     private func requestGetRecords(){
         let goalId = goals[currentGoal].id
-        RecordService.shared.getRecordsOfGoal(id: goalId, pageable: PageableModel(page: 0,
-                                                                                  size: Const.requestPagingSize)){ response in
+        RecordService.shared.getRecordsOfGoal(id: goalId, pageable: PageableModel(page: 0)){ response in
             switch response {
             case .success(let data):
                 print("LOG: success requestGetRecords", data)

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -114,7 +114,7 @@ extension ReviewViewController{
     private func requestGetRecords(){
         let goalId = goals[currentGoal].id
         RecordService.shared.getRecordsOfGoal(id: goalId, pageable: PageableModel(page: 0,
-                                                                                  size:  Const.requestPagingSize)){ response in
+                                                                                  size: Const.requestPagingSize)){ response in
             switch response {
             case .success(let data):
                 print("LOG: success requestGetRecords", data)
@@ -162,6 +162,7 @@ extension ReviewViewController: UICollectionViewDelegate, UICollectionViewDataSo
             guard let cell = collectionView.cellForItem(at: [0,0]) as? GoalTagCollectionViewCell else { return }
             cell.setUnselectState()
         }
+        currentGoal = indexPath.row
         cell.setSelectState()
     }
 
@@ -202,13 +203,9 @@ extension ReviewViewController: UITableViewDelegate, UITableViewDataSource{
             let cardIndex = dataIndexBy(indexPath)
             let record = records[cardIndex]
             
+            //        cell.delegate = self
             cell.mainView.dataBinding(with: record)
-            
-//            if let reaction = records[indexPath.row] {
-//                cell.mainView.myReactionButton.setImage(reaction.defaultImage, for: .normal)
-//            }
-//            cell.mainView.setOthersReaction(count: indexPath.row)
-    //        cell.delegate = self
+        
             return cell
         }
     }

--- a/POME/Presentation/Views/Friend/FriendDetailView.swift
+++ b/POME/Presentation/Views/Friend/FriendDetailView.swift
@@ -62,7 +62,6 @@ class FriendDetailView: BaseView {
         $0.setTypoStyleWithMultiLine(typoStyle: .title3)
     }
     let memoLabel = UILabel().then{
-        $0.text = "아휴 힘빠져 이젠 진짜 포기다 포기 도대체 뭐가 문제일까 현실을 되돌아볼 필요를 느낀다ㅠ 이정도 노력했으면 된거 아닌가 진짜 개 힘빠지네 그래서 오늘은 물 대신 라떼 한잔을 마셨습니다 ㅋ 라뗴 존맛탱~~ 다들 나흐바 시그니쳐 커피를 마셔주세요 설탕 솔솔 뿌려서 개맛있음"
         $0.textColor = Color.title
         $0.setTypoStyleWithMultiLine(typoStyle: .body2)
         $0.numberOfLines = 0

--- a/POME/Presentation/Views/Friend/FriendReactionSheetView.swift
+++ b/POME/Presentation/Views/Friend/FriendReactionSheetView.swift
@@ -31,7 +31,6 @@ class FriendReactionSheetView: BaseView {
     let countView = UIView()
     
     let countLabel = UILabel().then{
-        $0.text = "전체 6개"
         $0.setTypoStyleWithMultiLine(typoStyle: .subtitle3)
         $0.textColor = Color.body
     }

--- a/POME/Presentation/Views/Record/Register/RecordRegisterContentView.swift
+++ b/POME/Presentation/Views/Record/Register/RecordRegisterContentView.swift
@@ -7,40 +7,6 @@
 
 import UIKit
 
-struct PomeDateFormatter{
-    
-    static let formatter = DateFormatter().then{
-        $0.dateFormat = "yyyy.MM.dd"
-    }
-    
-    static func getTodayDate() -> String{
-        return formatter.string(from: Date())
-    }
-    
-    static func getDateString(_ date: CalendarSelectDate) -> String{
-        "\(date.year)." + convertIntToFormatterString(date.month) + "." + convertIntToFormatterString(date.date)
-    }
-    
-    static func getRecordDateString(_ date: String) -> String{
-        //'2023.02.23' > '2월 23일'
-        guard let date = PomeDateFormatter.formatter.date(from: date) else {
-            return ""
-        }
-        let formatter = DateFormatter().then{
-            $0.dateFormat = "M월 d일"
-        }
-        return formatter.string(from: date)
-    }
-    
-    static private func convertIntToFormatterString(_ int: Int) -> String{
-        int < 10 ? "0\(int)" : String(int)
-    }
-    
-    static func getDateType(from: String){
-        formatter.date(from: from)
-    }
-}
-
 class RecordRegisterContentView: BaseView {
     
     let titleView = RegisterCommonTitleView(title: "어떤 소비를 하셨나요?",

--- a/POME/Presentation/Views/Review/ReviewDetailView.swift
+++ b/POME/Presentation/Views/Review/ReviewDetailView.swift
@@ -23,12 +23,10 @@ class ReviewDetailView: BaseView {
     }
     
     let priceLabel = UILabel().then{
-        $0.text = "320,800원"
         $0.textColor = Color.title
         $0.setTypoStyleWithSingleLine(typoStyle: .title3)
     }
     let memoLabel = UILabel().then{
-        $0.text = "아휴 힘빠져 이젠 진짜 포기다 포기 도대체 뭐가 문제일까 현실을 되돌아볼 필요를 느낀다ㅠ 이정도 노력했으면 된거 아닌가 진짜 개 힘빠지네 그래서 오늘은 물 대신 라떼 한잔을 마셨습니다 ㅋ 라뗴 존맛탱~~ 다들 나흐바 시그니쳐 커피를 마셔주세요 설탕 솔솔 뿌려서 개맛있음"
         $0.textColor = Color.title
         $0.setTypoStyleWithMultiLine(typoStyle: .body2)
         $0.numberOfLines = 0
@@ -39,12 +37,10 @@ class ReviewDetailView: BaseView {
         $0.axis = .horizontal
     }
     let tagLabel = PaddingLabel().then{
-        $0.text = "커피 대신 물을 마시자"
         $0.textColor = Color.grey5
         $0.setTypoStyleWithSingleLine(typoStyle: .body3)
     }
     let timeLabel = UILabel().then{
-        $0.text = "· 44분 전"
         $0.textColor = Color.grey5
         $0.setTypoStyleWithSingleLine(typoStyle: .body3)
     }
@@ -160,21 +156,38 @@ class ReviewDetailView: BaseView {
             $0.height.equalTo(22)
         }
     }
+    //MARK: - Method
     
-    func setOthersReaction(thumnail: Reaction, count: Int){
+    func dataBinding(with record: RecordResponseModel){
+        /*
+        goalPromiseLabel.text = record.goalPromiseBinding
+        timeLabel.text = record.timeBinding
+        priceLabel.text = record.priceBinding
+        memoLabel.text = record.oneLineMind
         
-        if(count == 0){
-            //TODO: 0개일 때 어떤 이모지 사용...?
-            othersReactionButton.setImage(Image.emojiAdd, for: .normal)
-            return
-        }else if(count == 1){
-            othersReactionButton.setImage(thumnail.defaultImage, for: .normal)
+        firstEmotionTag.setTagInfo(when: .first, state: record.firstEmotionBinding)
+        secondEmotionTag.setTagInfo(when: .second, state: record.secondEmotionBinding)
+        myReactionBtn.setImage(record.myReactionBinding, for: .normal)
+        */
+        record.othersReactionCountBinding == 0 ? setOthersReactionEmpty() : setOthersReaction(thumbnail: record.othersThumbnailReactionBinding, count: record.othersReactionCountBinding)
+    }
+    
+    func setOthersReactionEmpty(){
+        othersReactionButton.backgroundColor = .white
+        othersReactionButton.isEnabled = false
+    }
+    
+    func setOthersReaction(thumbnail: Reaction, count: Int){
+        
+        othersReactionButton.isEnabled = true
+        
+        if(count == 1){
+            othersReactionButton.setImage(thumbnail.defaultImage, for: .normal)
             return
         }
         
         //count > 1인 경우 아래 코드 실행
         self.othersReactionButton.addSubview(othersReactionCountLabel)
-
         othersReactionCountLabel.snp.makeConstraints{
             $0.leading.top.equalToSuperview().offset(6)
             $0.centerX.centerY.equalToSuperview()
@@ -189,6 +202,6 @@ class ReviewDetailView: BaseView {
         }
         
         othersReactionCountLabel.text = countString
-        othersReactionButton.setImage(thumnail.blurImage, for: .normal)
+        othersReactionButton.setImage(thumbnail.blurImage, for: .normal)
     }
 }

--- a/POME/Presentation/Views/Review/ReviewDetailView.swift
+++ b/POME/Presentation/Views/Review/ReviewDetailView.swift
@@ -36,7 +36,7 @@ class ReviewDetailView: BaseView {
         $0.spacing = 2
         $0.axis = .horizontal
     }
-    let tagLabel = PaddingLabel().then{
+    let tagLabel = UILabel().then{
         $0.textColor = Color.grey5
         $0.setTypoStyleWithSingleLine(typoStyle: .body3)
     }
@@ -159,16 +159,16 @@ class ReviewDetailView: BaseView {
     //MARK: - Method
     
     func dataBinding(with record: RecordResponseModel){
-        /*
-        goalPromiseLabel.text = record.goalPromiseBinding
+
+        tagLabel.text = record.goalPromiseBinding
         timeLabel.text = record.timeBinding
         priceLabel.text = record.priceBinding
         memoLabel.text = record.oneLineMind
         
         firstEmotionTag.setTagInfo(when: .first, state: record.firstEmotionBinding)
         secondEmotionTag.setTagInfo(when: .second, state: record.secondEmotionBinding)
-        myReactionBtn.setImage(record.myReactionBinding, for: .normal)
-        */
+        myReactionButton.setImage(record.myReactionBinding, for: .normal)
+
         record.othersReactionCountBinding == 0 ? setOthersReactionEmpty() : setOthersReaction(thumbnail: record.othersThumbnailReactionBinding, count: record.othersReactionCountBinding)
     }
     


### PR DESCRIPTION
## What is this PR? 🔍
PageableResponseModel + NetworkResult 활용 

## Key Changes 🔑

### 1. PageableResponseModel

1. empty 프로퍼티 추가

2. content 프로퍼티 배열로 타입 변경

### 2. RecordOfGoalResponseModel 제거

+ RecordOfGoalResponseModel 제거하고 기존 PageableResponseModel 활용하는 식으로 코드 수정

### 3. RecordResponseModel 

+ createAt이 공백이 아닌 T로 날짜/시간이 구분되더라구요(스웨거랑 데이터가 다르군..) 
+ 위에 이슈로 인해 오늘 날짜 판별이 잘 안됐었는데 해결했습니다. 

### 4. PageableModel request시 활용

+ Pageable에 대한 요청 데이터임을 명확히 하기 위해서 struct 구조체 적용 시켰습니다

+ size 프로퍼티 기본 값 Const.requestPagingSize 설정 해놨습니다. (page 값만 지정해주면 됨)

### 5. PomeDateFormatter 파일 분리

## To Reviewers 📢
- 풀 받고 사용해주세요


## Related Issues ⛱
#143, #131