### PR TITLE
Fix/#195: 친구/회고탭 prepareForReuse 통한 데이터 바인딩 오류 수정

### DIFF
--- a/POME/Data/Model/PageableResponseModel.swift
+++ b/POME/Data/Model/PageableResponseModel.swift
@@ -10,5 +10,6 @@ import Foundation
 struct PageableResponseModel<T: Decodable>: Decodable{
     let content: [T]
     let empty: Bool
+    let last: Bool
 }
 

--- a/POME/Global/Resource/Extension/UITableView.swift
+++ b/POME/Global/Resource/Extension/UITableView.swift
@@ -24,8 +24,8 @@ extension UITableView{
         return cell
     }
     
-    final func cellForRow<T: BaseTableViewCell>(at indexPath: IndexPath, cellType: T.Type) -> T {
-        guard let cell = self.cellForRow(at: indexPath) as? T else { fatalError() }
+    final func cellForRow<T: BaseTableViewCell>(at indexPath: IndexPath, cellType: T.Type) -> T? {
+        guard let cell = self.cellForRow(at: indexPath) as? T else { return nil }
         return cell
     }
 }

--- a/POME/Presentation/Cells/Friend/FriendTableViewCell.swift
+++ b/POME/Presentation/Cells/Friend/FriendTableViewCell.swift
@@ -29,14 +29,6 @@ class FriendTableViewCell: BaseTableViewCell {
     
     //MARK: - LifeCycle
     
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
     override func prepareForReuse() {
         mainView.nameLabel.text = ""
         mainView.goalPromiseLabel.text = ""
@@ -45,7 +37,11 @@ class FriendTableViewCell: BaseTableViewCell {
         mainView.memoLabel.text = ""
         mainView.othersReactionCountLabel.text = ""
         
+        mainView.firstEmotionTag.setTagInfo(when: .first, state: .default)
+        mainView.secondEmotionTag.setTagInfo(when: .second, state: .default)
+        
         mainView.myReactionBtn.setImage(Image.emojiAdd, for: .normal)
+        mainView.othersReactionButton.setImage(.none, for: .normal)
     }
     
     //MARK: - Action

--- a/POME/Presentation/Cells/Review/ConsumeReviewTableViewCell.swift
+++ b/POME/Presentation/Cells/Review/ConsumeReviewTableViewCell.swift
@@ -24,6 +24,20 @@ class ConsumeReviewTableViewCell: BaseTableViewCell {
         $0.memoLabel.numberOfLines = 2
     }
     
+    override func prepareForReuse() {
+        mainView.tagLabel.text = ""
+        mainView.timeLabel.text = ""
+        mainView.priceLabel.text = ""
+        mainView.memoLabel.text = ""
+        mainView.othersReactionCountLabel.text = ""
+        
+        mainView.firstEmotionTag.setTagInfo(when: .first, state: .default)
+        mainView.secondEmotionTag.setTagInfo(when: .second, state: .default)
+        
+        mainView.myReactionButton.setImage(Image.emojiAdd, for: .normal)
+        mainView.othersReactionButton.setImage(.none, for: .normal)
+    }
+    
     override func setting(){
         super.setting()
         self.selectedBackgroundView = UIView()

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -17,12 +17,12 @@ class FriendViewController: BaseTabViewController, ControlIndexPath, Pageable {
     
     var page: Int = 0
     var isPaging: Bool = false
-    var hasNextPage: Bool = true
+    var hasNextPage: Bool = false
     
     var currentFriendIndex: Int = 0{
         didSet{
             page = 0
-            hasNextPage = true
+            hasNextPage = false
             currentFriendIndex == 0 ? requestGetAllFriendsRecords() : requestGetFriendCards()
         }
     }
@@ -31,8 +31,9 @@ class FriendViewController: BaseTabViewController, ControlIndexPath, Pageable {
     var friends = [FriendsResponseModel](){
         didSet{
             isTableViewEmpty()
-            let friendsCell = friendView.tableView.cellForRow(at: [0,0], cellType: FriendListTableViewCell.self)
-            friendsCell.collectionView.reloadData()
+            if let friendsCell = friendView.tableView.cellForRow(at: [0,0], cellType: FriendListTableViewCell.self){
+                friendsCell.collectionView.reloadData()
+            }
         }
     }
     var records = [RecordResponseModel](){
@@ -111,12 +112,10 @@ extension FriendViewController{
         isPaging = true
         page = page + 1
         
-        // Section 1을 reload하여 로딩 셀을 보여줌 (페이징 진행 중인 것을 확인할 수 있도록)
         DispatchQueue.main.async { [self] in
             friendView.tableView.reloadSections(IndexSet(integer: 1), with: .none)
         }
 
-        // 페이징 메소드 호출
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             self.currentFriendIndex == 0 ? self.requestGetAllFriendsRecords() : self.requestGetFriendCards()
         }
@@ -156,6 +155,7 @@ extension FriendViewController{
                 }else{
                     self.records.append(contentsOf: data)
                 }
+                self.hasNextPage = true
                 return
             default:
                 break
@@ -183,6 +183,7 @@ extension FriendViewController{
                 }else{
                     self.records.append(contentsOf: data)
                 }
+                self.hasNextPage = true
                 break
             default:
                 break

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -31,13 +31,13 @@ class FriendViewController: BaseTabViewController, ControlIndexPath, Pageable {
     var friends = [FriendsResponseModel](){
         didSet{
             isTableViewEmpty()
-            if let friendsCell = friendView.tableView.cellForRow(at: [0,0]) as? FriendListTableViewCell{
-                friendsCell.collectionView.reloadData()
-            }
+            let friendsCell = friendView.tableView.cellForRow(at: [0,0], cellType: FriendListTableViewCell.self)
+            friendsCell.collectionView.reloadData()
         }
     }
     var records = [RecordResponseModel](){
         didSet{
+            isPaging = false
             isTableViewEmpty()
             friendView.tableView.reloadData()
         }
@@ -151,7 +151,12 @@ extension FriendViewController{
                     self.recordRequestIsEmpty()
                     return
                 }
-                self.records = data
+                if(self.page == 0){
+                    self.records = data
+                }else{
+                    self.records.append(contentsOf: data)
+                }
+                return
             default:
                 break
             }
@@ -173,7 +178,11 @@ extension FriendViewController{
                     self.recordRequestIsEmpty()
                     return
                 }
-                self.records = data
+                if(self.page == 0){
+                    self.records = data
+                }else{
+                    self.records.append(contentsOf: data)
+                }
                 break
             default:
                 break

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -33,7 +33,6 @@ class ReviewViewController: BaseTabViewController, ControlIndexPath, Pageable {
         didSet{
             if let cell = self.mainView.tableView.cellForRow(at: [0,0]) as? GoalTagsTableViewCell{
                 cell.tagCollectionView.reloadData()
-                mainView.tableView.reloadData()
             }
         }
     }

--- a/POME/Presentation/Views/Friend/FriendDetailView.swift
+++ b/POME/Presentation/Views/Friend/FriendDetailView.swift
@@ -105,7 +105,7 @@ class FriendDetailView: BaseView {
         goalPromiseLabel.text = record.goalPromiseBinding
         timeLabel.text = record.timeBinding
         priceLabel.text = record.priceBinding
-        memoLabel.text = record.oneLineMind
+        memoLabel.text = record.useComment
         
         firstEmotionTag.setTagInfo(when: .first, state: record.firstEmotionBinding)
         secondEmotionTag.setTagInfo(when: .second, state: record.secondEmotionBinding)
@@ -115,7 +115,7 @@ class FriendDetailView: BaseView {
     }
     
     func setOthersReactionEmpty(){
-        othersReactionButton.backgroundColor = .white
+        othersReactionButton.setImage(.none, for: .normal)
         othersReactionButton.isEnabled = false
     }
     

--- a/POME/Presentation/Views/Review/ReviewDetailView.swift
+++ b/POME/Presentation/Views/Review/ReviewDetailView.swift
@@ -163,7 +163,7 @@ class ReviewDetailView: BaseView {
         tagLabel.text = record.goalPromiseBinding
         timeLabel.text = record.timeBinding
         priceLabel.text = record.priceBinding
-        memoLabel.text = record.oneLineMind
+        memoLabel.text = record.useComment
         
         firstEmotionTag.setTagInfo(when: .first, state: record.firstEmotionBinding)
         secondEmotionTag.setTagInfo(when: .second, state: record.secondEmotionBinding)
@@ -173,7 +173,7 @@ class ReviewDetailView: BaseView {
     }
     
     func setOthersReactionEmpty(){
-        othersReactionButton.backgroundColor = .white
+        othersReactionButton.setImage(.none, for: .normal)
         othersReactionButton.isEnabled = false
     }
     


### PR DESCRIPTION
## What is this PR? 🔍
친구/회고탭 prepareForReuse 통한 데이터 바인딩 오류 수정

## Key Changes 🔑
1. PageableResponseModel last 프로퍼티 추가
   - last 프로퍼티(마지막 페이지 여부)를 통해 추가 로딩 가능 여부 조정

2. 친구/회고탭 기록 셀 prepareForReuse 메서드 구현
   - 리액션 부분에서 UI 오류가 빈번하게 발생했었는데, Image none값 설정으로 버그 해결했습니다. 
   
3. UITableView cellForRow(cellType) 메서드 옵셔널 타입 반환
   - 친구탭에 적용을 했는데 계속 타입 캐스팅 실패로 인해 fatalError 발생
   - fatalError은 발생하지 않도록 방지하기 위해 그냥 옵셔널 타입 반환하도록 수정했습니다. 
   - cell 반환되면 if let이나 guard let 구문으로 옵셔널 제거해 사용해주시길 바랍니다.  

## To Reviewers 📢
- 공통 소스 부분 수정한 것이 있으니 풀 받고 사용해주세요

## Related Issues ⛱
#195