### PR TITLE
Fix/#200: 회고탭 필터링 통한 기록 조회로 API 수정

### DIFF
--- a/POME/Data/Model/Goal/GoalResponseModel.swift
+++ b/POME/Data/Model/Goal/GoalResponseModel.swift
@@ -16,12 +16,12 @@ struct GoalResponseModel: Decodable {
     let oneLineMind: String
     let price: Int
     let startDate: String
-    let isEnd: Bool
     let usePrice: Int
     let oneLineComment: String?
 }
 
 extension GoalResponseModel{
+    
     static let numberFormatter = NumberFormatter().then{
         $0.numberStyle = .decimal
     }
@@ -45,5 +45,9 @@ extension GoalResponseModel{
         var result = GoalResponseModel.numberFormatter.string(from: NSNumber(value: self.price)) ?? ""
         
         return "· \(result)원"
+    }
+    
+    var isEnd: Bool{
+        PomeDateFormatter.isDateEnd(self.endDate)
     }
 }

--- a/POME/Data/Model/Goal/GoalResponseModel.swift
+++ b/POME/Data/Model/Goal/GoalResponseModel.swift
@@ -36,14 +36,12 @@ extension GoalResponseModel{
     
     var usePriceBinding: String{
         // 가격 콤마 표시
-        var result = GoalResponseModel.numberFormatter.string(from: NSNumber(value: self.usePrice)) ?? ""
-        
+        let result = GoalResponseModel.numberFormatter.string(from: NSNumber(value: self.usePrice)) ?? ""
         return "\(result)원"
     }
     var priceBinding: String {
         // 가격 콤마 표시
-        var result = GoalResponseModel.numberFormatter.string(from: NSNumber(value: self.price)) ?? ""
-        
+        let result = GoalResponseModel.numberFormatter.string(from: NSNumber(value: self.price)) ?? ""
         return "· \(result)원"
     }
     

--- a/POME/Data/Model/Goal/GoalResponseModel.swift
+++ b/POME/Data/Model/Goal/GoalResponseModel.swift
@@ -11,6 +11,7 @@ struct GoalResponseModel: Decodable {
     let endDate: String
     let goalCategoryResponse: GoalCategoryResponseModel
     let id: Int
+    let isEnd: Bool
     let isPublic: Bool
     let nickname: String
     let oneLineMind: String
@@ -45,7 +46,7 @@ extension GoalResponseModel{
         return "· \(result)원"
     }
     
-    var isEnd: Bool{
+    var isGoalEnd: Bool{
         PomeDateFormatter.isDateEnd(self.endDate)
     }
 }

--- a/POME/Data/Model/Record/RecordResponseModel.swift
+++ b/POME/Data/Model/Record/RecordResponseModel.swift
@@ -22,7 +22,7 @@ struct EmotionResponseModel: Decodable{
     let firstEmotion: Int
     let secondEmotion: Int?
     var myEmotion: Int?
-    let friendEmotions: [FriendReactionResponseModel]?
+    let friendEmotions: [FriendReactionResponseModel]
 }
 
 struct FriendReactionResponseModel: Decodable{
@@ -51,7 +51,7 @@ extension RecordResponseModel{
     }
     
     var firstEmotionBinding: EmotionTag{
-        EmotionTag(rawValue: self.emotionResponse.firstEmotion ?? 0) ?? .default
+        EmotionTag(rawValue: self.emotionResponse.firstEmotion) ?? .default
     }
     
     var secondEmotionBinding: EmotionTag{
@@ -66,15 +66,15 @@ extension RecordResponseModel{
     }
     
     var othersThumbnailReactionBinding: Reaction{
-        Reaction(rawValue: self.emotionResponse.friendEmotions?.first!.emotionId ?? 1) ?? .happy
+        Reaction(rawValue: self.emotionResponse.friendEmotions.first!.emotionId) ?? .happy
     }
     
     var othersReactionCountBinding: Int{
-        self.emotionResponse.friendEmotions!.count ?? 0
+        self.emotionResponse.friendEmotions.count
     }
     
     var friendReactions: [FriendReactionResponseModel]{
-        self.emotionResponse.friendEmotions ?? []
+        self.emotionResponse.friendEmotions
     }
 }
 

--- a/POME/Data/Service/Friend/FriendService.swift
+++ b/POME/Data/Service/Friend/FriendService.swift
@@ -45,13 +45,13 @@ extension FriendService{
         }
     }
     
-    func getFriendRecord(id: String, pageable: PageableModel, completion: @escaping (NetworkResult<[RecordResponseModel]>) -> Void) {
+    func getFriendRecord(id: String, pageable: PageableModel, completion: @escaping (NetworkResult<PageableResponseModel<RecordResponseModel>>) -> Void) {
         requestDecoded(FriendRouter.getFriendRecord(id: id, pageable: pageable)){ response in
             completion(response)
         }
     }
     
-    func getAllFriendsRecord(pageable: PageableModel, completion: @escaping (NetworkResult<[RecordResponseModel]>) -> Void) {
+    func getAllFriendsRecord(pageable: PageableModel, completion: @escaping (NetworkResult<PageableResponseModel<RecordResponseModel>>) -> Void) {
         requestDecoded(FriendRouter.getAllFriendsRecord(pageable: pageable)){ response in
             completion(response)
         }

--- a/POME/Data/Service/Record/RecordRouter.swift
+++ b/POME/Data/Service/Record/RecordRouter.swift
@@ -14,7 +14,7 @@ enum RecordRouter: BaseRouter{
     case postRecord(request: RecordRegisterRequestModel)
     case getRecordsOfGoalByUser(id: Int, pageable: PageableModel)
     case getRecordsOfGoalByUserAtRecordTab(id: Int, pageable: PageableModel)    // 기록탭
-    case getRecordsOfGoalByUserAtReviewTab(id: Int, pageable: PageableModel)    // 회고탭
+    case getRecordsOfGoalByUserAtReviewTab(id: Int, firstEmotion: Int?, secondEmotion: Int?, pageable: PageableModel)    // 회고탭
     case getNoSecondEmoRecords(id: Int)     // 일주일이 지났고, 두 번째 감정을 남겨야하는 기록 조회
     case postSecondEmotion(id: Int, param: RecordSecondEmotionRequestModel)
 }
@@ -28,7 +28,7 @@ extension RecordRouter{
         case .postRecord:                                       return HTTPMethodURL.POST.record
         case .getRecordsOfGoalByUser(let id, _):                return HTTPMethodURL.GET.recordOfGoal + "/\(id)"
         case .getRecordsOfGoalByUserAtRecordTab(let id, _):        return HTTPMethodURL.GET.recordOfGoal + "/\(id)/record-tab"
-        case .getRecordsOfGoalByUserAtReviewTab(let id, _):    return HTTPMethodURL.GET.recordOfGoal + "/\(id)/retrospection-tab"
+        case .getRecordsOfGoalByUserAtReviewTab(let id, _, _, _):    return HTTPMethodURL.GET.recordOfGoal + "/\(id)/retrospection-tab"
         case .getNoSecondEmoRecords(let id):                    return HTTPMethodURL.GET.noSecondEmotionRecords + "/\(id)"
         case .postSecondEmotion(let id, _):                     return HTTPMethodURL.POST.secondEmotion + "/\(id)" + "/second-emotion"
 
@@ -54,10 +54,18 @@ extension RecordRouter{
         case .deleteRecord:                                             return .requestPlain
         case .postRecord(let request):                                  return .requestJSONEncodable(request)
         case .getRecordsOfGoalByUser(_, let pageable),
-                .getRecordsOfGoalByUserAtRecordTab(_, let pageable),
-                .getRecordsOfGoalByUserAtReviewTab(_ , let pageable):   return .requestParameters(parameters: ["page" : pageable.page,
+                .getRecordsOfGoalByUserAtRecordTab(_, let pageable):    return .requestParameters(parameters: ["page" : pageable.page,
                                                                                                                "size" : pageable.size,
                                                                                                                "sort" : pageable.sort],
+                                                                                                  encoding: URLEncoding.queryString)
+        case .getRecordsOfGoalByUserAtReviewTab(_, let firstEmotion,
+                                                let secondEmotion ,
+                                                let pageable):
+                                                                        return .requestParameters(parameters: ["page" : pageable.page,
+                                                                                                               "size" : pageable.size,
+                                                                                                               "sort" : pageable.sort,
+                                                                                                               "firstEmotion": firstEmotion ?? "",
+                                                                                                               "secondEmotion": secondEmotion ?? ""],
                                                                                                   encoding: URLEncoding.queryString)
         case .getNoSecondEmoRecords:                                    return .requestPlain
         case .postSecondEmotion(_, let param):                          return .requestJSONEncodable(param)

--- a/POME/Data/Service/Record/RecordService.swift
+++ b/POME/Data/Service/Record/RecordService.swift
@@ -44,8 +44,8 @@ extension RecordService{
         }
     }
     
-    func getRecordsOfGoalAtReviewTab(id: Int, pageable: PageableModel, completion: @escaping (NetworkResult<PageableResponseModel<RecordResponseModel>>) -> Void) {
-        requestDecoded(RecordRouter.getRecordsOfGoalByUserAtReviewTab(id: id, pageable: pageable)) { response in
+    func getRecordsOfGoalAtReviewTab(id: Int, firstEmotion: Int?, secondEmotion: Int?, pageable: PageableModel, completion: @escaping (NetworkResult<PageableResponseModel<RecordResponseModel>>) -> Void) {
+        requestDecoded(RecordRouter.getRecordsOfGoalByUserAtReviewTab(id: id, firstEmotion: firstEmotion, secondEmotion: secondEmotion, pageable: pageable)) { response in
             completion(response)
         }
     }

--- a/POME/Presentation/Cells/Review/GoalTagCollectionViewCell.swift
+++ b/POME/Presentation/Cells/Review/GoalTagCollectionViewCell.swift
@@ -21,23 +21,10 @@ class GoalTagCollectionViewCell: BaseCollectionViewCell {
     }
     
     //MARK: - LifeCycle
-    
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        
-        setUnselectState()
+    override func prepareForReuse() {
+        goalCategoryLabel.text = ""
+        setInactivateState()
     }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-//    override var isSelected: Bool {
-//        didSet {
-//            if isSelected {self.setSelectState()}
-//            else {self.setUnselectState()}
-//        }
-//    }
     
     //MARK: - Method
     
@@ -49,6 +36,11 @@ class GoalTagCollectionViewCell: BaseCollectionViewCell {
     func setUnselectState(){
         goalCategoryView.backgroundColor = .white
         goalCategoryLabel.textColor = Color.grey5
+    }
+    
+    func setUnselectState(with isEnd: Bool){
+        goalCategoryView.backgroundColor = .white
+        goalCategoryLabel.textColor = isEnd ? Color.grey3 : Color.grey5
     }
     
     func setInactivateState(){

--- a/POME/Presentation/Cells/Review/ScrollView/GoalDetailTableViewCell.swift
+++ b/POME/Presentation/Cells/Review/ScrollView/GoalDetailTableViewCell.swift
@@ -72,10 +72,7 @@ class GoalDetailTableViewCell: BaseTableViewCell{
     
     func bindingData(goal: GoalResponseModel){
         goal.isPublic ? goalIsPublicLabel.setPublicState() : goalIsPublicLabel.setLockState()
-        
         goalTitleLabel.text = goal.oneLineMind
-        
-        //TODO: 시간 계산 메서드 생성 및 데이터 바인딩
         goalRemainDateLabel.setRemainDate(diff: goal.remainDateBinding)
     }
 }

--- a/POME/Presentation/Cells/Review/ScrollView/GoalTagsTableViewCell.swift
+++ b/POME/Presentation/Cells/Review/ScrollView/GoalTagsTableViewCell.swift
@@ -9,8 +9,6 @@ import Foundation
 
 class GoalTagsTableViewCell: BaseTableViewCell{
     
-    static let cellIdentifier = "GoalTagsTableViewCell"
-    
     let tagCollectionView = UICollectionView(frame: .zero, collectionViewLayout: .init()).then{
         let flowLayout = UICollectionViewFlowLayout().then{
             $0.minimumInteritemSpacing = 8
@@ -18,6 +16,7 @@ class GoalTagsTableViewCell: BaseTableViewCell{
             $0.scrollDirection = .horizontal
         }
         
+        $0.backgroundColor = Color.transparent
         $0.collectionViewLayout = flowLayout
         $0.showsHorizontalScrollIndicator = false
         $0.contentInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -146,16 +146,7 @@ extension FriendViewController{
             switch response {
             case .success(let data):
                 print("LOG: success requestGetAllFriendsRecords", data)
-                if(data.isEmpty){
-                    self.recordRequestIsEmpty()
-                    return
-                }
-                if(self.page == 0){
-                    self.records = data
-                }else{
-                    self.records.append(contentsOf: data)
-                }
-                self.hasNextPage = true
+                self.processResponseGetRecords(data: data)
                 return
             default:
                 break
@@ -174,16 +165,7 @@ extension FriendViewController{
             switch result{
             case .success(let data):
                 print("LOG: success requestGetFriendCards", data)
-                if(data.isEmpty){
-                    self.recordRequestIsEmpty()
-                    return
-                }
-                if(self.page == 0){
-                    self.records = data
-                }else{
-                    self.records.append(contentsOf: data)
-                }
-                self.hasNextPage = true
+                self.processResponseGetRecords(data: data)
                 break
             default:
                 break
@@ -191,9 +173,23 @@ extension FriendViewController{
         }
     }
     
+    private func processResponseGetRecords(data: PageableResponseModel<RecordResponseModel>){
+        
+        hasNextPage = !data.last
+        
+        if(page == 0){
+            records = data.content
+        }else{
+            records.append(contentsOf: data.content)
+        }
+        
+        if(data.empty){
+            recordRequestIsEmpty()
+        }
+    }
+    
     func recordRequestIsEmpty() {
         isPaging = false
-        hasNextPage = false
         friendView.tableView.reloadSections(IndexSet(integer: 1), with: .none)
     }
     

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -182,7 +182,7 @@ extension ReviewViewController: UICollectionViewDelegate, UICollectionViewDataSo
 
         cell.goalCategoryLabel.text = goals.isEmpty ? "···" : goals[indexPath.row].goalNameBinding
     
-        currentGoal == indexPath.row ? cell.setSelectState() : cell.setUnselectState()
+        currentGoal == indexPath.row ? cell.setSelectState() : cell.setUnselectState(with: goals[indexPath.row].isEnd)
         
         return cell
     }
@@ -202,7 +202,7 @@ extension ReviewViewController: UICollectionViewDelegate, UICollectionViewDataSo
         guard let cell = collectionView.cellForItem(at: indexPath) as? GoalTagCollectionViewCell else { return }
         if(currentGoal == 0 && indexPath.row != 0){
             guard let cell = collectionView.cellForItem(at: [0,0]) as? GoalTagCollectionViewCell else { return }
-            cell.setUnselectState()
+            cell.setUnselectState(with: goals[indexPath.row].isEnd)
         }
         currentGoal = indexPath.row
         cell.setSelectState()
@@ -210,7 +210,7 @@ extension ReviewViewController: UICollectionViewDelegate, UICollectionViewDataSo
 
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         guard let cell = collectionView.cellForItem(at: indexPath) as? GoalTagCollectionViewCell else { return }
-        cell.setUnselectState()
+        cell.setUnselectState(with: goals[indexPath.row].isEnd)
     }
 }
 

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -168,7 +168,7 @@ extension ReviewViewController: UICollectionViewDelegate, UICollectionViewDataSo
 
         cell.goalCategoryLabel.text = goals.isEmpty ? "···" : goals[indexPath.row].goalNameBinding
     
-        currentGoal == indexPath.row ? cell.setSelectState() : cell.setUnselectState(with: goals[indexPath.row].isEnd)
+        currentGoal == indexPath.row ? cell.setSelectState() : cell.setUnselectState(with: goals[indexPath.row].isGoalEnd)
         
         return cell
     }
@@ -188,7 +188,7 @@ extension ReviewViewController: UICollectionViewDelegate, UICollectionViewDataSo
         guard let cell = collectionView.cellForItem(at: indexPath) as? GoalTagCollectionViewCell else { return }
         if(currentGoal == 0 && indexPath.row != 0){
             guard let cell = collectionView.cellForItem(at: [0,0]) as? GoalTagCollectionViewCell else { return }
-            cell.setUnselectState(with: goals[indexPath.row].isEnd)
+            cell.setUnselectState(with: goals[indexPath.row].isGoalEnd)
         }
         currentGoal = indexPath.row
         cell.setSelectState()
@@ -196,7 +196,7 @@ extension ReviewViewController: UICollectionViewDelegate, UICollectionViewDataSo
 
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         guard let cell = collectionView.cellForItem(at: indexPath) as? GoalTagCollectionViewCell else { return }
-        cell.setUnselectState(with: goals[indexPath.row].isEnd)
+        cell.setUnselectState(with: goals[indexPath.row].isGoalEnd)
     }
 }
 


### PR DESCRIPTION
## What is this PR? 🔍
회고탭 필터링 통한 기록 조회로 API 수정

## Key Changes 🔑

### 1. GoalResponseModel 프로퍼티 변경

기존 isEnd 프로퍼티가 응답 프로퍼티였는데, 응답값으로 사용안하기로 한 듯해
바인딩 프로퍼티로 변경했습니다. 

isEnd 통해 목표 종료 여부 확인할 수 있습니다. 

(isEnd 사용한다고 하길래 isGoalEnd로 네이밍 변경했습니다아... 아니 근데 왜 회고에서는 값이 이상한건데)

위 프로퍼티 사용 통해 회고탭 목표 종료 여부 UI 구현했습니다. 

### 2. GoalTagCollectionViewCell prepareForReuse 메서드 구현

> 

### 3. 친구탭 기록 조회 Pageable 응답 모델 적용

### 4. 회고탭 필터링 통한 기록 조회 API로 수정

근데 응답값이 필터링이 제대로 안된거 같아서 서버 문의해봐야 할 것 같습니다..

## To Reviewers 📢
- 풀 받고 써주세요


## Related Issues ⛱
#200