### PR TITLE
Refactor/#212: 기록 수정/삭제/리액션 등록 > 응답 결과로 데이터 binding

### DIFF
--- a/POME/Data/Service/Friend/FriendService.swift
+++ b/POME/Data/Service/Friend/FriendService.swift
@@ -14,7 +14,7 @@ final class FriendService: MultiMoyaService{
 
 extension FriendService{
     
-    func generateFriendEmotion(id: Int, emotion: Int, completion: @escaping (NetworkResult<BaseResponseModel<RecordResponseModel>>) -> Void) {
+    func generateFriendEmotion(id: Int, emotion: Int, completion: @escaping (NetworkResult<RecordResponseModel>) -> Void) {
         requestDecoded(FriendRouter.postEmotion(id: id, emotion: emotion), animate: true){ response in
             completion(response)
         }

--- a/POME/Data/Service/Friend/FriendService.swift
+++ b/POME/Data/Service/Friend/FriendService.swift
@@ -14,8 +14,8 @@ final class FriendService: MultiMoyaService{
 
 extension FriendService{
     
-    func generateFriendEmotion(id: Int, emotion: Int, completion: @escaping (NetworkResult<Any>) -> Void) {
-        requestNoResultAPI(FriendRouter.postEmotion(id: id, emotion: emotion), animate: true){ response in
+    func generateFriendEmotion(id: Int, emotion: Int, completion: @escaping (NetworkResult<BaseResponseModel<RecordResponseModel>>) -> Void) {
+        requestDecoded(FriendRouter.postEmotion(id: id, emotion: emotion), animate: true){ response in
             completion(response)
         }
     }

--- a/POME/Data/Service/Record/RecordService.swift
+++ b/POME/Data/Service/Record/RecordService.swift
@@ -14,7 +14,7 @@ final class RecordService: MultiMoyaService{
 
 extension RecordService{
     
-    func modifyRecord(id: Int, request: RecordRegisterRequestModel, completion: @escaping (NetworkResult<BaseResponseModel<RecordResponseModel>>) -> Void) {
+    func modifyRecord(id: Int, request: RecordRegisterRequestModel, completion: @escaping (NetworkResult<RecordResponseModel>) -> Void) {
         requestDecoded(RecordRouter.patchRecord(id: id, request: request), animate: true){ response in
             completion(response)
         }

--- a/POME/Data/Service/Record/RecordService.swift
+++ b/POME/Data/Service/Record/RecordService.swift
@@ -14,8 +14,8 @@ final class RecordService: MultiMoyaService{
 
 extension RecordService{
     
-    func modifyRecord(id: Int, request: RecordRegisterRequestModel, completion: @escaping (NetworkResult<Any>) -> Void) {
-        requestNoResultAPI(RecordRouter.patchRecord(id: id, request: request), animate: true){ response in
+    func modifyRecord(id: Int, request: RecordRegisterRequestModel, completion: @escaping (NetworkResult<BaseResponseModel<RecordResponseModel>>) -> Void) {
+        requestDecoded(RecordRouter.patchRecord(id: id, request: request), animate: true){ response in
             completion(response)
         }
     }

--- a/POME/Presentation/ViewControllers/Friend/FriendDetailViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendDetailViewController.swift
@@ -7,14 +7,25 @@
 
 import UIKit
 
+protocol FriendDetailEditable{
+    func processResponseModifyReactionInDetail(index: Int, record: RecordResponseModel)
+}
+
 class FriendDetailViewController: BaseViewController {
     
-    var record: RecordResponseModel
+    var delegate: FriendDetailEditable!
+    private let recordIndex: Int
+    private var record: RecordResponseModel{
+        didSet{
+            mainView.dataBinding(with: record)
+        }
+    }
     
-    var emoijiFloatingView: EmojiFloatingView!
-    let mainView = FriendDetailView()
+    private var emoijiFloatingView: EmojiFloatingView!
+    private let mainView = FriendDetailView()
     
-    init(record: RecordResponseModel){
+    init(recordIndex: Int, record: RecordResponseModel){
+        self.recordIndex = recordIndex
         self.record = record
         super.init(nibName: nil, bundle: nil)
     }
@@ -82,11 +93,11 @@ extension FriendDetailViewController{
         FriendService.shared.generateFriendEmotion(id: record.id,
                                                    emotion: reactionIndex){ result in
             switch result{
-            case .success:
-                self.record.emotionResponse.myEmotion = reactionIndex
-                self.mainView.myReactionBtn.setImage(reaction.defaultImage, for: .normal)
+            case .success(let data):
+                self.record = data
                 self.emoijiFloatingView?.dismiss()
                 ToastMessageView.generateReactionToastView(type: reaction).show(in: self)
+                self.delegate.processResponseModifyReactionInDetail(index: self.recordIndex, record: self.record)
                 break
             default:
                 break

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -64,9 +64,13 @@ class FriendViewController: BaseTabViewController, ControlIndexPath, Pageable {
     var emoijiFloatingView: EmojiFloatingView!
     
     //MARK: - Override
-
-    override func viewWillAppear(_ animated: Bool) {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
         requestGetFriends()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
         print(UserManager.token, UserManager.userId)
     }
     

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -324,9 +324,11 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Reco
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let dataIndex = dataIndexBy(indexPath)
-        let record = records[dataIndex]
-        let vc = FriendDetailViewController(record: record)
+        let recordIndex = dataIndexBy(indexPath)
+        let record = records[recordIndex]
+        let vc = FriendDetailViewController(recordIndex: recordIndex, record: record).then{
+            $0.delegate = self
+        }
         self.navigationController?.pushViewController(vc, animated: true)
     }
     
@@ -373,5 +375,11 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Reco
         alert.addAction(cancelAction)
              
         self.present(alert, animated: true)
+    }
+}
+
+extension FriendViewController: FriendDetailEditable{
+    func processResponseModifyReactionInDetail(index: Int, record: RecordResponseModel) {
+        records[index] = record
     }
 }

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -140,7 +140,7 @@ extension FriendViewController{
 extension FriendViewController{
     
     private func requestGetFriends(){
-        FriendService.shared.getFriends(pageable: PageableModel(page: 1)){ result in
+        FriendService.shared.getFriends(pageable: PageableModel(page: page)){ result in
             switch result{
             case .success(let data):
                     print("LOG: 'success' requestGetFriends", data)
@@ -218,8 +218,8 @@ extension FriendViewController{
         FriendService.shared.generateFriendEmotion(id: records[cellIndex].id,
                                                    emotion: reactionIndex){ result in
             switch result{
-            case .success:
-                self.records[cellIndex].emotionResponse.myEmotion = reactionIndex
+            case .success(let data):
+                self.records[cellIndex] = data
                 self.emoijiFloatingView?.dismiss()
                 ToastMessageView.generateReactionToastView(type: reaction).show(in: self)
                 break

--- a/POME/Presentation/ViewControllers/Record/Register/RecordModifyContentViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/RecordModifyContentViewController.swift
@@ -9,12 +9,14 @@ import Foundation
 
 class RecordModifyContentViewController: RecordRegisterContentViewController{
     
-    let goal: GoalResponseModel
-    let record: RecordResponseModel!
+    private let goal: GoalResponseModel
+    private let record: RecordResponseModel!
+    private let completion: (RecordResponseModel) -> Void
     
-    init(goal: GoalResponseModel, record: RecordResponseModel){
+    init(goal: GoalResponseModel, record: RecordResponseModel, completion: @escaping (RecordResponseModel) -> Void){
         self.goal = goal
         self.record = record
+        self.completion = completion
         super.init(mainView: RecordContentView())
     }
     
@@ -64,7 +66,8 @@ extension RecordModifyContentViewController{
         RecordService.shared.modifyRecord(id: recordManager.recordId,
                                           request: request){ response in
             switch response{
-            case .success:
+            case .success(let data):
+                self.completion(data)
                 self.navigationController?.popViewController(animated: true)
                 break
             default:

--- a/POME/Presentation/ViewControllers/Review/ReviewDetailViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewDetailViewController.swift
@@ -87,7 +87,10 @@ extension ReviewDetailViewController: RecordCellWithEmojiDelegate{
         let editAction = UIAlertAction(title: "수정하기", style: .default){ _ in
             alert.dismiss(animated: true)
             let vc = RecordModifyContentViewController(goal: self.goal,
-                                                       record: self.record)
+                                                       record: self.record){
+                self.record = $0
+                self.delegate.processResponseModifyRecordInDetail(index: self.recordIndex, record: self.record)
+            }
             self.navigationController?.pushViewController(vc, animated: true)
         }
 

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -61,7 +61,8 @@ class ReviewViewController: BaseTabViewController, ControlIndexPath, Pageable {
     let mainView = ReviewView()
     var emoijiFloatingView: EmojiFloatingView!
     
-    override func viewWillAppear(_ animated: Bool) {
+    override func viewDidLoad() {
+        super.viewDidLoad()
         requestGetGoals()
     }
     
@@ -409,7 +410,7 @@ extension ReviewViewController{
         }
     }
     
-    func requestDeleteRecord(indexPath: IndexPath){
+    private func requestDeleteRecord(indexPath: IndexPath){
         let index = dataIndexBy(indexPath)
         let record = records[index]
         RecordService.shared.deleteRecord(id: record.id){ response in
@@ -424,7 +425,6 @@ extension ReviewViewController{
             }
         }
     }
-    
     private func processResponseDeleteRecord(indexPath: IndexPath){
         self.willDelete = true
         let recordIndex = dataIndexBy(indexPath)

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -313,7 +313,9 @@ extension ReviewViewController: RecordCellWithEmojiDelegate{
         let editAction = UIAlertAction(title: "수정하기", style: .default){ _ in
             alert.dismiss(animated: true)
             let vc = RecordModifyContentViewController(goal: self.goals[self.currentGoal],
-                                                       record: self.records[recordIndex])
+                                                       record: self.records[recordIndex]){
+                self.records[recordIndex] = $0
+            }
             self.navigationController?.pushViewController(vc, animated: true)
         }
 

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -398,8 +398,9 @@ extension ReviewViewController{
         FriendService.shared.generateFriendEmotion(id: records[cellIndex].id,
                                                    emotion: reactionIndex){ result in
             switch result{
-            case .success:
-                self.records[cellIndex].emotionResponse.myEmotion = reactionIndex
+            case .success(let data):
+                print("LOG: SUCCESS requestGenerateFriendCardEmotion", data)
+                self.records[cellIndex] = data
                 self.emoijiFloatingView?.dismiss()
                 ToastMessageView.generateReactionToastView(type: reaction).show(in: self)
                 break

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -231,37 +231,37 @@ extension ReviewViewController: UITableViewDelegate, UITableViewDataSource{
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         
         if(indexPath.section == 1){
-            let cell = tableView.dequeueReusableCell(for: indexPath, cellType: LoadingTableViewCell.self)
-            cell.startLoading()
+            let cell = tableView.dequeueReusableCell(for: indexPath, cellType: LoadingTableViewCell.self).then{
+                $0.startLoading()
+            }
             return cell
         }
         
         switch indexPath.row{
         case 0:
-            let cell = tableView.dequeueReusableCell(for: indexPath, cellType: GoalTagsTableViewCell.self)
-            cell.tagCollectionView.delegate = self
-            cell.tagCollectionView.dataSource = self
+            let cell = tableView.dequeueReusableCell(for: indexPath, cellType: GoalTagsTableViewCell.self).then{
+                $0.tagCollectionView.delegate = self
+                $0.tagCollectionView.dataSource = self
+            }
             return cell
         case 1:
             let cell = tableView.dequeueReusableCell(for: indexPath, cellType: GoalDetailTableViewCell.self)
             goals.isEmpty ? cell.bindingEmptyData() : cell.bindingData(goal: goals[currentGoal])
             return cell
         case 2:
-            let cell = tableView.dequeueReusableCell(for: indexPath, cellType: ReviewFilterTableViewCell.self)
-            cell.firstEmotionFilter.filterButton.addTarget(self, action: #selector(filterButtonDidClicked), for: .touchUpInside)
-            cell.secondEmotionFilter.filterButton.addTarget(self, action: #selector(filterButtonDidClicked), for: .touchUpInside)
-            cell.reloadingButton.addTarget(self, action: #selector(filterInitializeButtonDidClicked), for: .touchUpInside)
+            let cell = tableView.dequeueReusableCell(for: indexPath, cellType: ReviewFilterTableViewCell.self).then{
+                $0.firstEmotionFilter.filterButton.addTarget(self, action: #selector(filterButtonDidClicked), for: .touchUpInside)
+                $0.secondEmotionFilter.filterButton.addTarget(self, action: #selector(filterButtonDidClicked), for: .touchUpInside)
+                $0.reloadingButton.addTarget(self, action: #selector(filterInitializeButtonDidClicked), for: .touchUpInside)
+            }
             return cell
         default:
-            //TODO: 기록 데이터 바인딩
-            let cell = tableView.dequeueReusableCell(for: indexPath, cellType: ConsumeReviewTableViewCell.self)
-            
             let cardIndex = dataIndexBy(indexPath)
             let record = records[cardIndex]
-            
-            cell.delegate = self
-            cell.mainView.dataBinding(with: record)
-        
+            let cell = tableView.dequeueReusableCell(for: indexPath, cellType: ConsumeReviewTableViewCell.self).then{
+                $0.delegate = self
+                $0.mainView.dataBinding(with: record)
+            }
             return cell
         }
     }
@@ -271,7 +271,9 @@ extension ReviewViewController: UITableViewDelegate, UITableViewDataSource{
             return
         }
         let dataIndex = dataIndexBy(indexPath)
-        let vc = ReviewDetailViewController(goal: goals[currentGoal], record: records[dataIndex])
+        let vc = ReviewDetailViewController(recordIndex: dataIndex, goal: goals[currentGoal], record: records[dataIndex]).then{
+            $0.delegate = self
+        }
         self.navigationController?.pushViewController(vc, animated: true)
     }
 }
@@ -432,5 +434,16 @@ extension ReviewViewController{
         self.records.remove(at: recordIndex)
         self.mainView.tableView.deleteRows(at: [indexPath], with: .fade)
         self.willDelete = false
+    }
+}
+
+extension ReviewViewController: ReviewDetailEditable{
+    
+    func processResponseModifyRecordInDetail(index: Int, record: RecordResponseModel){
+        records[index] = record
+    }
+    
+    func processResponseDeleteRecordInDetail(index: Int){
+        records.remove(at: index)
     }
 }


### PR DESCRIPTION
## What is this PR? 🔍
기록 수정/삭제/리액션 등록 > 응답 결과로 데이터 binding

## Key Changes 🔑
1. 리액션 등록/수정시 기존 리액션 데이터만 변경 > 기록 데이터 전체를 응답 결과로 바인딩
2. 기록 삭제, 수정시 delegate 활용해 탭 화면까지 변경 데이터 연결
3. 각 VC간 데이터 연결로 인해 기존 viewWillAppear에서 초기 데이터 조회 요청 했던 걸, viewDidLoad로 옮겼습니다. 

## To Reviewers 📢
- 풀 받고 사용해주세요

## Related Issues ⛱
close #212