### PR TITLE
Feature/#206: 친구/회고탭 등 네트워크 오류시 팝업 > 재요청 기능 추가

### DIFF
--- a/POME/Global/Source/PopUp/NetworkErrorAlertViewController.swift
+++ b/POME/Global/Source/PopUp/NetworkErrorAlertViewController.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct NetworkAlert{
-    static func show(in viewController: BaseViewController, completion: @escaping () -> Void){
+    static func show(in viewController: UIViewController, completion: @escaping () -> Void){
         let alert = NetworkErrorAlertViewController().then{
             $0.loadViewIfNeeded()
             $0.modalPresentationStyle = .overFullScreen

--- a/POME/Presentation/ViewControllers/Friend/FriendDetailViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendDetailViewController.swift
@@ -94,12 +94,17 @@ extension FriendDetailViewController{
                                                    emotion: reactionIndex){ result in
             switch result{
             case .success(let data):
+                print("LOG: success requestGenerateFriendCardEmotion", data)
                 self.record = data
                 self.emoijiFloatingView?.dismiss()
                 ToastMessageView.generateReactionToastView(type: reaction).show(in: self)
                 self.delegate.processResponseModifyReactionInDetail(index: self.recordIndex, record: self.record)
                 break
             default:
+                print("LOG: fail requestGenerateFriendCardEmotion", result)
+                NetworkAlert.show(in: self){ [weak self] in
+                    self?.requestGenerateFriendCardEmotion(reactionIndex: reactionIndex)
+                }
                 break
             }
         }

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -152,8 +152,10 @@ extension FriendViewController{
                     self.requestGetAllFriendsRecords()
                 break
             default:
-                print("LOG: 'fail' requestGetFriends")
-                print(result)
+                print("LOG: 'fail' requestGetFriends", result)
+                NetworkAlert.show(in: self){ [weak self] in
+                    self?.requestGetFriends()
+                }
                 break
             }
         }
@@ -168,6 +170,10 @@ extension FriendViewController{
                 self.processResponseGetRecords(data: data)
                 return
             default:
+                print("LOG: fail requestGetAllFriendsRecords", response)
+                NetworkAlert.show(in: self){ [weak self] in
+                    self?.requestGetAllFriendsRecords()
+                }
                 break
             }
         }
@@ -188,6 +194,10 @@ extension FriendViewController{
                 self.processResponseGetRecords(data: data)
                 break
             default:
+                print("LOG: fail requestGetFriendCards", result)
+                NetworkAlert.show(in: self){ [weak self] in
+                    self?.requestGetFriendCards()
+                }
                 break
             }
         }
@@ -223,12 +233,16 @@ extension FriendViewController{
                                                    emotion: reactionIndex){ result in
             switch result{
             case .success(let data):
+                print("LOG: success requestGenerateFriendCardEmotion", data)
                 self.records[cellIndex] = data
                 self.emoijiFloatingView?.dismiss()
                 ToastMessageView.generateReactionToastView(type: reaction).show(in: self)
                 break
             default:
-                print(result)
+                print("LOG: fail requestGenerateFriendCardEmotion", result)
+                NetworkAlert.show(in: self){ [weak self] in
+                    self?.requestGenerateFriendCardEmotion(reactionIndex: reactionIndex)
+                }
                 break
             }
         }

--- a/POME/Presentation/ViewControllers/Record/Register/RecordModifyContentViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/RecordModifyContentViewController.swift
@@ -63,13 +63,17 @@ extension RecordModifyContentViewController{
         print(request)
         
         RecordService.shared.modifyRecord(id: recordManager.recordId,
-                                          request: request){ response in
-            switch response{
+                                          request: request){ result in
+            switch result{
             case .success(let data):
                 self.completion(data)
                 self.navigationController?.popViewController(animated: true)
                 break
             default:
+                print(result)
+                NetworkAlert.show(in: self){ [weak self] in
+                    self?.requestModifyRecord()
+                }
                 break
             }
             

--- a/POME/Presentation/ViewControllers/Record/Register/RecordRegisterContentViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/RecordRegisterContentViewController.swift
@@ -144,7 +144,7 @@ class RecordRegisterContentViewController: BaseViewController {
         let sheet = CategorySelectSheetViewController(data: goals).loadAndShowBottomSheet(in: self)
         sheet.completion = { selectIndex in
             let goal = self.goals[selectIndex]
-            self.recordManager.goalId =  goal.id//TODO: - GOAL id값으로 넣어주기
+            self.recordManager.goalId = goal.id
             self.mainView.goalField.infoTextField.text = goal.goalNameBinding
             self.mainView.goalField.infoTextField.sendActions(for: .valueChanged)
         }
@@ -244,6 +244,9 @@ extension RecordRegisterContentViewController{
                 break
             default:
                 print(result)
+                NetworkAlert.show(in: self){ [weak self] in
+                    self?.requestGetGoals()
+                }
                 break
             }
         }

--- a/POME/Presentation/ViewControllers/Record/Register/RecordRegisterEmotionSelectViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/RecordRegisterEmotionSelectViewController.swift
@@ -140,6 +140,9 @@ extension RecordRegisterEmotionSelectViewController{
                 break
             default:
                 print(result)
+                NetworkAlert.show(in: self){ [weak self] in
+                    self?.requestGenerateRecord()
+                }
                 break
             }
         }

--- a/POME/Presentation/ViewControllers/Review/ReviewDetailViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewDetailViewController.swift
@@ -119,17 +119,21 @@ extension ReviewDetailViewController{
     internal func requestGenerateFriendCardEmotion(reactionIndex: Int){
         guard let reaction = Reaction(rawValue: reactionIndex) else { return }
         
-        //MARK: - 결과로 데이터 재정의하는 걸로 변경하기.
         FriendService.shared.generateFriendEmotion(id: record.id,
                                                    emotion: reactionIndex){ result in
             switch result{
             case .success(let data):
+                print("LOG: SUCCESS requestGenerateFriendCardEmotion", data)
                 self.record = data
                 self.emoijiFloatingView?.dismiss()
                 ToastMessageView.generateReactionToastView(type: reaction).show(in: self)
                 self.delegate.processResponseModifyRecordInDetail(index: self.recordIndex, record: self.record)
                 break
             default:
+                print("LOG: fail requestGenerateFriendCardEmotion")
+                NetworkAlert.show(in: self){ [weak self] in
+                    self?.requestGenerateFriendCardEmotion(reactionIndex: reactionIndex)
+                }
                 break
             }
         }
@@ -139,12 +143,15 @@ extension ReviewDetailViewController{
         RecordService.shared.deleteRecord(id: record.id){ response in
             switch response {
             case .success:
+                print("LOG: success requestDeleteRecord")
                 self.delegate.processResponseDeleteRecordInDetail(index: self.recordIndex)
                 self.navigationController?.popViewController(animated: true)
-                print("LOG: success requestDeleteRecord")
                 break
             default:
                 print("LOG: fail requestGetRecords", response)
+                NetworkAlert.show(in: self){ [weak self] in
+                    self?.requestDeleteRecord()
+                }
                 break
             }
         }

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -350,6 +350,9 @@ extension ReviewViewController{
                 break
             default:
                 print("LOG: fail requestGetGoals", response)
+                NetworkAlert.show(in: self){ [weak self] in
+                    self?.requestGetGoals()
+                }
                 break
             }
         }
@@ -370,6 +373,9 @@ extension ReviewViewController{
                 return
             default:
                 print("LOG: fail requestGetRecords", response)
+                NetworkAlert.show(in: self){ [weak self] in
+                    self?.requestGetRecords()
+                }
                 break
             }
         }
@@ -409,7 +415,10 @@ extension ReviewViewController{
                 ToastMessageView.generateReactionToastView(type: reaction).show(in: self)
                 break
             default:
-                print(result)
+                print("LOG: fail requestGenerateFriendCardEmotion", result)
+                NetworkAlert.show(in: self){ [weak self] in
+                    self?.requestGenerateFriendCardEmotion(reactionIndex: reactionIndex)
+                }
                 break
             }
         }
@@ -426,6 +435,9 @@ extension ReviewViewController{
                 break
             default:
                 print("LOG: fail requestGetRecords", response)
+                NetworkAlert.show(in: self){ [weak self] in
+                    self?.requestDeleteRecord(indexPath: indexPath)
+                }
                 break
             }
         }

--- a/POME/Presentation/Views/Friend/FriendDetailView.swift
+++ b/POME/Presentation/Views/Friend/FriendDetailView.swift
@@ -24,7 +24,6 @@ class FriendDetailView: BaseView {
     }
     
     //user stackView
-    
     let topStackView = UIStackView().then{
         $0.spacing = 2
         $0.axis = .horizontal
@@ -32,17 +31,17 @@ class FriendDetailView: BaseView {
     
     let nameLabel = UILabel().then{
         $0.textColor = Color.body
-        $0.setTypoStyleWithMultiLine(typoStyle: .subtitle3)
+        $0.setTypoStyleWithSingleLine(typoStyle: .subtitle3)
     }
     
     let goalPromiseLabel = PaddingLabel().then{
         $0.textColor = Color.grey5
-        $0.setTypoStyleWithMultiLine(typoStyle: .body3)
+        $0.setTypoStyleWithSingleLine(typoStyle: .body3)
     }
     
     let timeLabel = UILabel().then{
         $0.textColor = Color.grey5
-        $0.setTypoStyleWithMultiLine(typoStyle: .body3)
+        $0.setTypoStyleWithSingleLine(typoStyle: .body3)
     }
 
     //
@@ -64,7 +63,7 @@ class FriendDetailView: BaseView {
     //
     let priceLabel = UILabel().then{
         $0.textColor = Color.title
-        $0.setTypoStyleWithMultiLine(typoStyle: .title3)
+        $0.setTypoStyleWithSingleLine(typoStyle: .title3)
     }
     let memoLabel = UILabel().then{
         $0.textColor = Color.title


### PR DESCRIPTION
## What is this PR? 🔍
친구/회고탭 등 네트워크 오류시 팝업 > 재요청 기능 추가

## Key Changes 🔑

### 1. 네트워크 오류 팝업 및 재요청 기능
1. 친구탭
2. 친구 상세
3. 회고탭
4. 회고 상세
5. 기록 생성
6. 기록 수정

위 페이지들에 적용 완료

### 2. 네트워크 오류 팝업 show 메서드 viewController 매개변수 타입 BaseVC > UIVC으로 확장

+ TabBar는 BaseVC이 아니라서 UIVC으로 타입 확장했습니다

## To Reviewers 📢
- 풀 받고 사용해주세요


## Related Issues ⛱
#206 