### PR TITLE
BugFix/#218: 리액션 플로팅 뷰 하단 공백 충분치 않은 경우 띄우지 않게 하기

### DIFF
--- a/POME/Global/Source/Const.swift
+++ b/POME/Global/Source/Const.swift
@@ -16,6 +16,7 @@ struct Const{
 struct Device{
     static let WIDTH: CGFloat = UIScreen.main.bounds.size.width
     static let HEIGHT: CGFloat = UIScreen.main.bounds.size.height
+    static let tabBarHeight: CGFloat = UITabBar().frame.height
 }
 
 struct Offset{

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -352,19 +352,38 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Reco
     
     func presentEmojiFloatingView(indexPath: IndexPath) {
 
-        self.currentEmotionSelectCardIndex = dataIndexBy(indexPath)
-        
-        emoijiFloatingView = EmojiFloatingView().then{
-            $0.delegate = self
-            $0.completion = {
-                print("LOG: emoijiFloatingView completion closure called")
-                self.currentEmotionSelectCardIndex = nil
-                self.emoijiFloatingView = nil
+        isSufficientToShowFloatingView(indexPath: indexPath){
+            
+            currentEmotionSelectCardIndex = dataIndexBy(indexPath)
+            emoijiFloatingView = EmojiFloatingView().then{
+                $0.delegate = self
+                $0.completion = {
+                    print("LOG: emoijiFloatingView completion closure called")
+                    self.currentEmotionSelectCardIndex = nil
+                    self.emoijiFloatingView = nil
+                }
             }
-        }
 
-        guard let cell = friendView.tableView.cellForRow(at: indexPath) as? FriendTableViewCell else { return }
-        emoijiFloatingView.show(in: self, standard: cell)
+            guard let cell = friendView.tableView.cellForRow(at: indexPath) as? FriendTableViewCell else { return }
+            emoijiFloatingView.show(in: self, standard: cell)
+        }
+    }
+    
+    private func isSufficientToShowFloatingView(indexPath: IndexPath, closure: () -> Void){
+        
+        let rectOfCellInTableView = friendView.tableView.rectForRow(at: indexPath) //5번째 셀의 좌표 값
+        let rectOfCellInSuperview = friendView.tableView.convert(rectOfCellInTableView, to: self.view)
+
+        let viewPosition = CGPoint(x: rectOfCellInSuperview.origin.x,
+                                   y: rectOfCellInSuperview.origin.y + rectOfCellInSuperview.height)
+        
+        if(Device.HEIGHT - viewPosition.y - Device.tabBarHeight - self.view.safeAreaInsets.bottom >= 74){
+            print("LOG: EMOJI FLOATING VIEW TEST true")
+            closure()
+        }else{
+            print("LOG: EMOJI FLOATING VIEW TEST falase")
+            return
+        }
     }
     
     func presentReactionSheet(indexPath: IndexPath) {

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -281,20 +281,40 @@ extension ReviewViewController: UITableViewDelegate, UITableViewDataSource{
 extension ReviewViewController: RecordCellWithEmojiDelegate{
     
     func presentEmojiFloatingView(indexPath: IndexPath) {
-
-        self.currentEmotionSelectCardIndex = dataIndexBy(indexPath)
         
-        emoijiFloatingView = EmojiFloatingView().then{
-            $0.delegate = self
-            $0.completion = {
-                print("LOG: emoijiFloatingView completion closure called")
-                self.currentEmotionSelectCardIndex = nil
-                self.emoijiFloatingView = nil
+        isSufficientToShowFloatingView(indexPath: indexPath){
+            
+            self.currentEmotionSelectCardIndex = dataIndexBy(indexPath)
+            
+            emoijiFloatingView = EmojiFloatingView().then{
+                $0.delegate = self
+                $0.completion = {
+                    print("LOG: emoijiFloatingView completion closure called")
+                    self.currentEmotionSelectCardIndex = nil
+                    self.emoijiFloatingView = nil
+                }
             }
+            
+            guard let cell = mainView.tableView.cellForRow(at: indexPath) as? ConsumeReviewTableViewCell else { return }
+            emoijiFloatingView.show(in: self, standard: cell)
         }
+    }
+    
+    private func isSufficientToShowFloatingView(indexPath: IndexPath, closure: () -> Void){
+        
+        let rectOfCellInTableView = mainView.tableView.rectForRow(at: indexPath) //5번째 셀의 좌표 값
+        let rectOfCellInSuperview = mainView.tableView.convert(rectOfCellInTableView, to: self.view)
 
-        guard let cell = mainView.tableView.cellForRow(at: indexPath) as? ConsumeReviewTableViewCell else { return }
-        emoijiFloatingView.show(in: self, standard: cell)
+        let viewPosition = CGPoint(x: rectOfCellInSuperview.origin.x,
+                                   y: rectOfCellInSuperview.origin.y + rectOfCellInSuperview.height)
+        
+        if(Device.HEIGHT - viewPosition.y - Device.tabBarHeight - self.view.safeAreaInsets.bottom >= 74){
+            print("LOG: EMOJI FLOATING VIEW TEST true")
+            closure()
+        }else{
+            print("LOG: EMOJI FLOATING VIEW TEST falase")
+            return
+        }
     }
     
     func presentReactionSheet(indexPath: IndexPath) {


### PR DESCRIPTION
## What is this PR? 🔍
리액션 플로팅 뷰 하단 공백 충분치 않은 경우 띄우지 않게 하기

## Key Changes 🔑

기존 리액션 플로팅 뷰가 디바이스 하단에 위치(마지막 셀이 아니라)하게 되는 셀에서 리액션 플로팅 뷰를 띄우는 경우, 
하단 공백이 충분치 않은 경우 tab bar에 가려지는 등 UI에 문제 발생.

cell 위치 계산 통해 플로팅 뷰 하단 offset 값으로 지정한 74보다 작은 경우는 아예 띄우지 않도록 수정했습니다. 

## To Reviewers 📢
- 풀 받고 써주세요


## Related Issues ⛱
#218