### PR TITLE
Refactor/#229: 친구 리스트 데이터 변동 여부에 따른 API 조회 구분

### DIFF
--- a/POME.xcodeproj/project.pbxproj
+++ b/POME.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		EE2628CF2992058C0013137C /* LoadingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2628CE2992058C0013137C /* LoadingTableViewCell.swift */; };
 		EE2628D1299231230013137C /* Pageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2628D0299231230013137C /* Pageable.swift */; };
 		EE44601F2983D1EB00B1A311 /* GoalCategoryResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE44601E2983D1EB00B1A311 /* GoalCategoryResponseModel.swift */; };
+		EE49615D29A47FE9000DA88C /* FriendListChangeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE49615C29A47FE9000DA88C /* FriendListChangeManager.swift */; };
 		EE79C29F29937CA1006A9AA2 /* FriendProfileImageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE79C29E29937CA1006A9AA2 /* FriendProfileImageManager.swift */; };
 		EE7C9FF4298A510300D2F238 /* PomeDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7C9FF3298A510300D2F238 /* PomeDateFormatter.swift */; };
 		EE8C2BF8298F5DBE00BE52B4 /* RecordModifyContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8C2BF7298F5DBE00BE52B4 /* RecordModifyContentViewController.swift */; };
@@ -439,6 +440,7 @@
 		EE2628CE2992058C0013137C /* LoadingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingTableViewCell.swift; sourceTree = "<group>"; };
 		EE2628D0299231230013137C /* Pageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pageable.swift; sourceTree = "<group>"; };
 		EE44601E2983D1EB00B1A311 /* GoalCategoryResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalCategoryResponseModel.swift; sourceTree = "<group>"; };
+		EE49615C29A47FE9000DA88C /* FriendListChangeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendListChangeManager.swift; sourceTree = "<group>"; };
 		EE79C29E29937CA1006A9AA2 /* FriendProfileImageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendProfileImageManager.swift; sourceTree = "<group>"; };
 		EE7C9FF3298A510300D2F238 /* PomeDateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PomeDateFormatter.swift; sourceTree = "<group>"; };
 		EE8C2BF7298F5DBE00BE52B4 /* RecordModifyContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordModifyContentViewController.swift; sourceTree = "<group>"; };
@@ -1475,6 +1477,7 @@
 			isa = PBXGroup;
 			children = (
 				EE79C29E29937CA1006A9AA2 /* FriendProfileImageManager.swift */,
+				EE49615C29A47FE9000DA88C /* FriendListChangeManager.swift */,
 			);
 			path = Friend;
 			sourceTree = "<group>";
@@ -2044,6 +2047,7 @@
 				5724EC6E2918CEFC00DC529B /* FriendTableViewCell.swift in Sources */,
 				233964A1292ECC06000F6BAC /* GoalWithProgressBarView.swift in Sources */,
 				57CCA78F292B0AF6007E22D1 /* EmotionFilterSheetCollectionViewCell.swift in Sources */,
+				EE49615D29A47FE9000DA88C /* FriendListChangeManager.swift in Sources */,
 				570304C42978193E00AAC56D /* UITableView.swift in Sources */,
 				5724EC592917734C00DC529B /* RecordViewController.swift in Sources */,
 				EE98F0D52980EFC0007BFCCD /* GoalRouter.swift in Sources */,

--- a/POME/Presentation/Cells/AddFriend/FriendSearchTableViewCell.swift
+++ b/POME/Presentation/Cells/AddFriend/FriendSearchTableViewCell.swift
@@ -96,6 +96,7 @@ class FriendSearchTableViewCell: BaseTableViewCell {
     }
     private func generateNewFriend(id: String){
         FriendService.shared.generateNewFriend(id: id) { result in
+            FriendListChangeManager.shared.isChange = true
             print("\(id) - 친구 추가")
         }
     }

--- a/POME/Presentation/Utils/Friend/FriendListChangeManager.swift
+++ b/POME/Presentation/Utils/Friend/FriendListChangeManager.swift
@@ -1,0 +1,21 @@
+//
+//  FriendListChangeManager.swift
+//  POME
+//
+//  Created by 박소윤 on 2023/02/21.
+//
+
+import Foundation
+
+final class FriendListChangeManager{
+    
+    static let shared = FriendListChangeManager()
+    
+    private init() { }
+    
+    var isChange = false
+    
+    func initialize(){
+        isChange = false
+    }
+}

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -17,8 +17,8 @@ class FriendViewController: BaseTabViewController, ControlIndexPath, Pageable {
     //MARK: - Property
     
     var page: Int = 0{
-        didSet{
-            if(page == 0){
+        willSet{
+            if(newValue == 0){
                 hasNextPage = false
             }
         }

--- a/POME/Presentation/ViewControllers/MyPage/MypageFriendViewController.swift
+++ b/POME/Presentation/ViewControllers/MyPage/MypageFriendViewController.swift
@@ -115,6 +115,7 @@ extension MypageFriendViewController {
                     if data.success {
                         print("친구 삭제 성공")
                         // 친구 목록 다시 불러오기
+                        FriendListChangeManager.shared.isChange = true
                         self.getFriends()
                     }
                     break


### PR DESCRIPTION
## What is this PR? 🔍
친구 리스트 데이터 변동 여부에 따른 API 조회 구분

## Key Changes 🔑

+ 친구 상세 페이지등에 들어갔다 나왔을 때 기존 셀 위치 등 유지하기 위해 viewDidLoad에 조회 기능을 넣었었음
+ 기존에 친구 리스트 조회를 처음 load했을 경우에만 되도록 진행 (추가/삭제를 생각하지 못함)
+ 친구 리스트의 경우 계속해서 데이터 재조회를 해야겠다고 판단
+ 친구 리스트 변경이 이뤄졌을 경우에만 전체 친구로 선택 셀 초기화 + 전체 친구로 기록 조회 위해 케이스 구분해 API 조회 구현했습니다. 
+ 위의 케이스 구분 위해 FriendListChangeManager 싱글톤 클래스를 구현해 친구 추가/삭제 api 요청 성공시 변경됐음을 알 수 있도록 했습니다. 

## To Reviewers 📢
- 파일 추가했으니 풀 받고 써주세요


## Related Issues ⛱
close #229