### PR TITLE
친구 검색 페이지 오류 해결

### DIFF
--- a/POME/Global/Resource/Default/EmptyView.swift
+++ b/POME/Global/Resource/Default/EmptyView.swift
@@ -89,9 +89,9 @@ class EmptyView {
         }
         let messageLabel = UILabel().then{
             $0.textColor = Color.grey5
-            $0.textAlignment = .center
             $0.text = message
             $0.setTypoStyleWithMultiLine(typoStyle: .subtitle2)
+            $0.textAlignment = .center
             $0.numberOfLines = 0
             $0.sizeToFit()
         }

--- a/POME/Presentation/ViewControllers/Friend/FriendSearchViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendSearchViewController.swift
@@ -18,6 +18,9 @@ class FriendSearchViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        let tap = UITapGestureRecognizer(target: view, action: #selector(UIView.endEditing))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
     }
     override func viewDidAppear(_ animated: Bool) {
         self.tabBarController?.tabBar.isHidden = true
@@ -67,6 +70,7 @@ class FriendSearchViewController: BaseViewController {
                 
         self.name.skip(1).distinctUntilChanged()
             .subscribe( onNext: { newValue in
+                self.setFriendSearchEmptyView()
                 self.searchFriend(id: newValue)
 //                print("name changed : \(newValue) ")
             })
@@ -107,17 +111,19 @@ class FriendSearchViewController: BaseViewController {
         self.friendSearchView.searchTextField.text = currName
         return currName
     }
-}
-// MARK: - TableView delegate
-extension FriendSearchViewController: UITableViewDelegate, UITableViewDataSource {
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    func setFriendSearchEmptyView() {
         let count = self.friendData.count ?? 0
         if count == 0 {
             EmptyView(self.friendSearchView.searchTableView).setCenterEmptyView(Image.warning, "검색 결과가 없어요\n다른 닉네임으로 검색해볼까요?")
         } else {
             EmptyView(self.friendSearchView.searchTableView).hideEmptyView()
         }
-
+    }
+}
+// MARK: - TableView delegate
+extension FriendSearchViewController: UITableViewDelegate, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        let count = self.friendData.count ?? 0
         return count
     }
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/POME/Presentation/ViewControllers/Friend/FriendSearchViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendSearchViewController.swift
@@ -70,7 +70,6 @@ class FriendSearchViewController: BaseViewController {
                 
         self.name.skip(1).distinctUntilChanged()
             .subscribe( onNext: { newValue in
-                self.setFriendSearchEmptyView()
                 self.searchFriend(id: newValue)
 //                print("name changed : \(newValue) ")
             })
@@ -113,6 +112,7 @@ class FriendSearchViewController: BaseViewController {
     }
     func setFriendSearchEmptyView() {
         let count = self.friendData.count ?? 0
+        print("count:", count)
         if count == 0 {
             EmptyView(self.friendSearchView.searchTableView).setCenterEmptyView(Image.warning, "검색 결과가 없어요\n다른 닉네임으로 검색해볼까요?")
         } else {
@@ -146,6 +146,12 @@ extension FriendSearchViewController: UITableViewDelegate, UITableViewDataSource
 //MARK: - API
 extension FriendSearchViewController {
     private func searchFriend(id: String){
+        if id.isEmpty {
+            self.friendData.removeAll()
+            self.friendSearchView.searchTableView.reloadData()
+            self.friendSearchView.searchTableView.backgroundView?.isHidden = true
+            return
+        }
         FriendService.shared.getFriendSearch(id: id) { result in
             switch result {
                 case .success(let data):
@@ -153,6 +159,7 @@ extension FriendSearchViewController {
                     print(data.data)
                 
                     self.friendData = data.data ?? []
+                    self.setFriendSearchEmptyView()
                     self.friendSearchView.searchTableView.reloadData()
                 
                     break


### PR DESCRIPTION
## What is this PR? 🔍
친구 검색 페이지 오류 해결
## Key Changes 🔑
1. 첫 화면일 때 문구 제거
2. 빈 결과값일 때의 문구 레이아웃 수정
3. 검색값이 비었을 때 예외처리: 빈 화면
4. 화면 터치 시 키보드 내리기

## To Reviewers 📢
확인 부탁드립니다


## Related Issues ⛱
