### PR TITLE
Fix/#232: 친구탭 TabBar로 인한 하단 margin 관련 버그 해결

### DIFF
--- a/POME/Global/Source/Const.swift
+++ b/POME/Global/Source/Const.swift
@@ -16,7 +16,6 @@ struct Const{
 struct Device{
     static let WIDTH: CGFloat = UIScreen.main.bounds.size.width
     static let HEIGHT: CGFloat = UIScreen.main.bounds.size.height
-    static let tabBarHeight: CGFloat = UITabBar().frame.height
 }
 
 struct Offset{

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -71,6 +71,7 @@ class FriendViewController: BaseTabViewController, ControlIndexPath, Pageable {
     
     override func viewWillAppear(_ animated: Bool) {
         if(friendsChangeManager.isChange){
+            friendView.tableView.scrollToRow(at: [0,0], at: .top, animated: false)
             requestGetFriendsInitialize()
             friendsChangeManager.initialize()
             return

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -16,13 +16,7 @@ class FriendViewController: BaseTabViewController, ControlIndexPath, Pageable {
     
     //MARK: - Property
     
-    var page: Int = 0{
-        willSet{
-            if(newValue == 0){
-                hasNextPage = false
-            }
-        }
-    }
+    var page: Int = 0
     var isPaging: Bool = false
     var hasNextPage: Bool = false
     private var willLoadingViewAnimate: Bool{
@@ -32,7 +26,7 @@ class FriendViewController: BaseTabViewController, ControlIndexPath, Pageable {
     var currentFriendIndex: Int = 0{
         didSet{
             page = 0
-            currentFriendIndex == 0 ? requestGetAllFriendsRecords() : requestGetFriendCards()
+            hasNextPage = false
         }
     }
     var currentEmotionSelectCardIndex: Int?
@@ -164,6 +158,7 @@ extension FriendViewController{
             case .success(let data):
                 print("LOG: 'success' requestGetFriends", data)
                 self.friends = data
+                self.requestGetAllFriendsRecords()
                 break
             default:
                 print("LOG: 'fail' requestGetFriends", result)
@@ -348,6 +343,7 @@ extension FriendViewController: UICollectionViewDelegate, UICollectionViewDataSo
         guard let cell = collectionView.cellForItem(at: indexPath) as? FriendCollectionViewCell else { return }
         cell.setSelectState(row: indexPath.row)
         currentFriendIndex = indexPath.row
+        currentFriendIndex == 0 ? requestGetAllFriendsRecords() : requestGetFriendCards()
     }
     
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -89,10 +89,13 @@ class FriendViewController: BaseTabViewController, ControlIndexPath, Pageable {
         
         super.layout()
         
+        let tabBarHeight = self.tabBarController?.tabBar.frame.height
+        
         self.view.addSubview(friendView)
         friendView.snp.makeConstraints{
             $0.top.equalToSuperview().offset(Offset.VIEW_CONTROLLER_TOP)
-            $0.leading.trailing.bottom.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalToSuperview().offset(-tabBarHeight!)
         }
     }
     
@@ -435,7 +438,7 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Reco
         let viewPosition = CGPoint(x: rectOfCellInSuperview.origin.x,
                                    y: rectOfCellInSuperview.origin.y + rectOfCellInSuperview.height)
         
-        if(Device.HEIGHT - viewPosition.y - Device.tabBarHeight - self.view.safeAreaInsets.bottom >= 74){
+        if(Device.HEIGHT - viewPosition.y - self.view.safeAreaInsets.bottom >= 74){ //Device.HEIGHT - viewPosition.y - Device.tabBarHeight - self.view.safeAreaInsets.bottom
             print("LOG: EMOJI FLOATING VIEW TEST true")
             closure()
         }else{

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -308,7 +308,7 @@ extension ReviewViewController: RecordCellWithEmojiDelegate{
         let viewPosition = CGPoint(x: rectOfCellInSuperview.origin.x,
                                    y: rectOfCellInSuperview.origin.y + rectOfCellInSuperview.height)
         
-        if(Device.HEIGHT - viewPosition.y - Device.tabBarHeight - self.view.safeAreaInsets.bottom >= 74){
+        if(Device.HEIGHT - viewPosition.y - self.view.safeAreaInsets.bottom >= 74){
             print("LOG: EMOJI FLOATING VIEW TEST true")
             closure()
         }else{


### PR DESCRIPTION
## What is this PR? 🔍
친구탭 TabBar로 인한 하단 margin 오류 해결

## Key Changes 🔑

+ 친구탭에서 친구 추가 등 다른 ViewController에 들어갔다가 pop한 경우, tabBar로 인해 기록 tableView의 offset이 제대로 적용되지 않는 버그가 발생했었습니다. 

+ tabBar 상단에 view의 하단을 맞춰 viewController pop에도 UI에 변화가 생기지 않도록 수정했습니다. 

+ 추가로, 친구리스트에 변화가 생긴 경우 전체 친구 리스트 조회 api가 동작되도록 했었는데, 이때 맨 처음 기록이 보이도록 추가로 설정해놨습니다. 

## To Reviewers 📢
- 풀 받고 써주세요


## Related Issues ⛱
close #232