### PR TITLE
refactor: GoalTagCollectionViewCell estimatedSize 메서드 추가

### DIFF
--- a/POME/Presentation/Cells/Review/GoalTagCollectionViewCell.swift
+++ b/POME/Presentation/Cells/Review/GoalTagCollectionViewCell.swift
@@ -51,11 +51,8 @@ class GoalTagCollectionViewCell: BaseCollectionViewCell {
     //MARK: - Override
     
     override func hierarchy() {
-        
         super.hierarchy()
-        
-        self.baseView.addSubview(goalCategoryView)
-        
+        baseView.addSubview(goalCategoryView)
         goalCategoryView.addSubview(goalCategoryLabel)
     }
     
@@ -66,11 +63,30 @@ class GoalTagCollectionViewCell: BaseCollectionViewCell {
         goalCategoryView.snp.makeConstraints{
             $0.top.leading.trailing.bottom.equalToSuperview()
         }
-        
         goalCategoryLabel.snp.makeConstraints{
             $0.top.equalToSuperview().offset(5)
             $0.leading.equalToSuperview().offset(12)
             $0.centerX.centerY.equalToSuperview()
         }
+    }
+    
+    static func estimatedSize() -> CGSize{
+        let testLabel = UILabel().then{
+            $0.setTypoStyleWithSingleLine(typoStyle: .title4)
+            $0.textAlignment = .center
+            $0.text = "···"
+        }
+        let width = testLabel.intrinsicContentSize.width + 12 * 2
+        return CGSize(width: width, height: 30)
+    }
+    
+    static func estimatedSize(title: String) -> CGSize{
+        let testLabel = UILabel().then{
+            $0.setTypoStyleWithSingleLine(typoStyle: .title4)
+            $0.textAlignment = .center
+            $0.text = title
+        }
+        let width = testLabel.intrinsicContentSize.width + 12 * 2
+        return CGSize(width: width, height: 30)
     }
 }

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -186,14 +186,7 @@ extension ReviewViewController: UICollectionViewDelegate, UICollectionViewDataSo
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        
-        let testLabel = UILabel().then{
-            $0.text = goals.isEmpty ? "···" : goals[indexPath.row].goalNameBinding
-            $0.setTypoStyleWithSingleLine(typoStyle: .title4)
-        }
-        
-        let width = testLabel.intrinsicContentSize.width + 12 * 2
-        return CGSize(width: width, height: 30)
+        goals.isEmpty ? GoalTagCollectionViewCell.estimatedSize() : GoalTagCollectionViewCell.estimatedSize(title: goals[indexPath.row].goalNameBinding)
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {


### PR DESCRIPTION
## What is this PR? 🔍
GoalTagCollectionViewCell estimatedSize 메서드 추가

## Key Changes 🔑

GoalTagCollectionView를 기록, 회고탭에서 재사용하는데 
사이즈 설정을 각 탭에서 다르게 사용하고 있었어서 이 부분 메서드 호출하는 식으로 해 통일 시키고자 했습니다. 

+ estimatedSize() : empty인 경우
+ estimatedSize(title: ) : title이 있는 경우


회고탭에서는 아래와 같이 적용시켰습니다. 

``` swift
func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
    goals.isEmpty ? GoalTagCollectionViewCell.estimatedSize() : GoalTagCollectionViewCell.estimatedSize(title: goals[indexPath.row].goalNameBinding)
}
```

## To Reviewers 📢

- 풀 받고 기록탭에서 목표Cell 사이즈 수정해주시면 됩니다. 


## Related Issues ⛱
