### PR TITLE
Fix/#242: 친구탭 리액션 QA 반영 > QA 기획 부분 수정 완료

### DIFF
--- a/POME/Presentation/Cells/Friend/FriendTableViewCell.swift
+++ b/POME/Presentation/Cells/Friend/FriendTableViewCell.swift
@@ -33,6 +33,8 @@ class FriendTableViewCell: BaseTableViewCell {
         
         mainView.myReactionBtn.setImage(Image.emojiAdd, for: .normal)
         mainView.othersReactionButton.setImage(.none, for: .normal)
+        
+        mainView.othersReactionCountLabel.isHidden = true
     }
     
     //MARK: - Action

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -275,7 +275,6 @@ extension FriendViewController{
         }
     }
     
-    
     private func requestHideFriendRecord(indexPath: IndexPath){
 
         let index = dataIndexBy(indexPath)

--- a/POME/Presentation/Views/Friend/FriendDetailView.swift
+++ b/POME/Presentation/Views/Friend/FriendDetailView.swift
@@ -84,9 +84,11 @@ class FriendDetailView: BaseView {
     lazy var othersReactionButton = UIButton()
     
     lazy var othersReactionCountLabel = UILabel().then{
-        $0.setTypoStyleWithMultiLine(typoStyle: .subtitle3)
+        $0.setTypoStyleWithSingleLine(typoStyle: .subtitle3)
         $0.textColor = .white
+        $0.textAlignment = .center
         $0.isUserInteractionEnabled = false
+        $0.isHidden = true
     }
     
     lazy var moreButton = UIButton().then{
@@ -122,25 +124,15 @@ class FriendDetailView: BaseView {
     }
     
     func setOthersReactionEmpty(){
+        othersReactionCountLabel.isHidden = true
         othersReactionButton.setImage(.none, for: .normal)
         othersReactionButton.isEnabled = false
     }
     
     func setOthersReaction(thumbnail: Reaction, count: Int){
         
+        othersReactionCountLabel.isHidden = false
         othersReactionButton.isEnabled = true
-        
-        if(count == 1){
-            othersReactionButton.setImage(thumbnail.defaultImage, for: .normal)
-            return
-        }
-        
-        //count > 1인 경우 아래 코드 실행
-        self.othersReactionButton.addSubview(othersReactionCountLabel)
-        othersReactionCountLabel.snp.makeConstraints{
-            $0.leading.top.equalToSuperview().offset(6)
-            $0.centerX.centerY.equalToSuperview()
-        }
         
         let countString: String!
         
@@ -181,6 +173,8 @@ class FriendDetailView: BaseView {
 
         reactionStackView.insertArrangedSubview(othersReactionButton, at: 0)
         reactionStackView.insertArrangedSubview(myReactionBtn, at: 0)
+        
+        othersReactionButton.addSubview(othersReactionCountLabel)
     }
 
 
@@ -256,6 +250,11 @@ class FriendDetailView: BaseView {
         
         othersReactionButton.snp.makeConstraints{
             $0.width.height.equalTo(28)
+        }
+        othersReactionCountLabel.snp.makeConstraints{
+            $0.leading.trailing.top.bottom.equalToSuperview()
+//            $0.leading.top.equalToSuperview().offset(6)
+//            $0.centerX.centerY.equalToSuperview()
         }
         
         moreButton.snp.makeConstraints{


### PR DESCRIPTION
## What is this PR? 🔍
친구탭 리액션 QA 반영 > QA 기획 부분 수정 완료

## Key Changes 🔑

오늘 회의시간에 친구탭 리액션 부분 설명 듣고 수정 완료했습니다. 
+ 1개가 뜨는 경우에 기존 defaultImage 사용 > blurImage 사용
+ 카운팅 무조건 총 개수로 1개일 때부터 띄우기

## To Reviewers 📢
- 풀 받고 써주세요


## Related Issues ⛱
close #242