### PR TITLE
#254: RecordViewController 처음 로드시 목표 조회 2번 발생 오류 수정

### DIFF
--- a/POME/Global/Source/TabBar/TabBarController.swift
+++ b/POME/Global/Source/TabBar/TabBarController.swift
@@ -28,8 +28,8 @@ class TabBarController: UITabBarController {
             switch result{
             case .success(let data):
                 print("LOG: SUCCESS GENERATE TOKEN")
-                self.recordViewController.token = data.accessToken ?? "" 
                 UserManager.token = data.accessToken
+                self.recordViewController.requestGetGoals()
                 break
             default:
                 print("LOG: FAIL GENERATE TOKEN")


### PR DESCRIPTION
## What is this PR? 🔍
RecordViewController 처음 로드시 목표 조회 2번 발생 오류 수정

## Key Changes 🔑
- RecordViewController를 처음 로드한 경우 기존 코드는 token 값 변동에 따라 목표 조회가 이뤄져 2번 토큰 발급 시점에 따라 목표 조회 2번 발생되는 문제 발생
- 처음 로드한 경우는 viewWillApear의 목표 조회 메서드 수행되지 않도록 로직 구현했습니다. 

## To Reviewers 📢
- 테스트 한번 해주세요


## Related Issues ⛱
#254