### PR TITLE
Fix/#268-270: UI 버그 몇 가지 해결

### DIFF
--- a/POME/Domain/ViewModel/Goal/GoalContentRegisterViewModel.swift
+++ b/POME/Domain/ViewModel/Goal/GoalContentRegisterViewModel.swift
@@ -51,7 +51,7 @@ class GoalContentRegisterViewModel{
         
         let canMoveNext = requestObservable
             .map { category, promise, price in
-                return !category.isEmpty && !promise.isEmpty && !price.isEmpty
+                return !category.isEmpty && !promise.isEmpty && !price.isEmpty && Int(price.replacingOccurrences(of: ",", with: ""))! > 0
             }.asDriver(onErrorJustReturn: false)
 
         return Output(categoryText: category,

--- a/POME/Domain/ViewModel/Record/Register/RecordRegisterContentViewModel.swift
+++ b/POME/Domain/ViewModel/Record/Register/RecordRegisterContentViewModel.swift
@@ -45,7 +45,7 @@ class RecordRegisterContentViewModel{
         let canMoveNext = requestObservable
             .map{ category, date, price, detail in
                 return !category.isEmpty && !date.isEmpty
-                && !price.isEmpty
+                && !price.isEmpty && Int(price.replacingOccurrences(of: ",", with: ""))! > 0
                 && detail != input.detailTextViewplaceholder
                 && !detail.isEmpty
             }.asDriver(onErrorJustReturn: false)

--- a/POME/Presentation/Cells/Review/GoalTagCollectionViewCell.swift
+++ b/POME/Presentation/Cells/Review/GoalTagCollectionViewCell.swift
@@ -23,6 +23,7 @@ class GoalTagCollectionViewCell: BaseCollectionViewCell {
     //MARK: - LifeCycle
     override func prepareForReuse() {
         goalCategoryLabel.text = ""
+        goalCategoryLabel.textColor = .white
         setInactivateState()
     }
     

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -334,6 +334,10 @@ extension FriendViewController: UICollectionViewDelegate, UICollectionViewDataSo
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath){
         
+        if let willDeselctCell = collectionView.cellForItem(at: [0, currentFriendIndex]) as? FriendCollectionViewCell{
+            willDeselctCell.setUnselectState(row: currentFriendIndex)
+        }
+        
         if(currentFriendIndex == 0 && indexPath.row != 0){
             guard let friendListCell = friendView.tableView.cellForRow(at: [0,0]) as? FriendListTableViewCell,
                     let cell = friendListCell.collectionView.cellForItem(at: [0,0]) as? FriendCollectionViewCell else { return }
@@ -344,11 +348,6 @@ extension FriendViewController: UICollectionViewDelegate, UICollectionViewDataSo
         cell.setSelectState(row: indexPath.row)
         currentFriendIndex = indexPath.row
         currentFriendIndex == 0 ? requestGetAllFriendsRecords() : requestGetFriendCards()
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-        guard let cell = collectionView.cellForItem(at: indexPath) as? FriendCollectionViewCell else { return }
-        cell.setUnselectState(row: indexPath.row)
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize{

--- a/POME/Presentation/ViewControllers/Register/Register/AppRegisterViewController.swift
+++ b/POME/Presentation/ViewControllers/Register/Register/AppRegisterViewController.swift
@@ -184,8 +184,6 @@ extension AppRegisterViewController {
         UserService.shared.signIn(model: signInRequestModel) { result in
             switch result {
             case .success(let data):
-                // 기록탭으로 이동
-                self.navigationController?.pushViewController(TabBarController(), animated: true)
                 // 유저 정보 저장
                 let token = data.accessToken ?? ""
                 let userId = data.userId ?? ""
@@ -198,6 +196,9 @@ extension AppRegisterViewController {
                 UserDefaults.standard.set(profileImg, forKey: UserDefaultKey.profileImg)
                 // 자동 로그인을 위해 phoneNum과 token을 기기에 저장
                 UserDefaults.standard.set(self.phone.value, forKey: UserDefaultKey.phoneNum)
+                
+                // 기록탭으로 이동
+                self.navigationController?.pushViewController(TabBarController(), animated: true)
                 break
             default:
                 break

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -310,7 +310,7 @@ extension ReviewViewController{
             switch response{
             case .success(let data):
                 print("LOG: success requestGetGoals", data)
-                goals = data.content
+                goals = data.content.filter{ !$0.isEnd }
                 requestGetRecords()
                 break
             default:

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -61,8 +61,8 @@ class ReviewViewController: BaseTabViewController, ControlIndexPath, Pageable {
     let mainView = ReviewView()
     var emoijiFloatingView: EmojiFloatingView!
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    override func viewWillAppear(_ animated: Bool) {
+        page = 0
         requestGetGoals()
     }
     

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -188,20 +188,21 @@ extension ReviewViewController: UICollectionViewDelegate, UICollectionViewDataSo
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         goals.isEmpty ? GoalTagCollectionViewCell.estimatedSize() : GoalTagCollectionViewCell.estimatedSize(title: goals[indexPath.row].name)
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
+        if let willDeselctCell = collectionView.cellForItem(at: [0, currentGoal]) as? GoalTagCollectionViewCell{
+            willDeselctCell.setUnselectState(with: goals[currentGoal].isGoalEnd)
+        }
+        
         guard let cell = collectionView.cellForItem(at: indexPath) as? GoalTagCollectionViewCell else { return }
         if(currentGoal == 0 && indexPath.row != 0){
-            guard let cell = collectionView.cellForItem(at: [0,0]) as? GoalTagCollectionViewCell else { return }
-            cell.setUnselectState(with: goals[indexPath.row].isGoalEnd)
+            guard let initialCell = collectionView.cellForItem(at: [0,0]) as? GoalTagCollectionViewCell else { return }
+            initialCell.setUnselectState(with: goals[0].isGoalEnd)
         }
+
         currentGoal = indexPath.row
         cell.setSelectState()
-    }
-
-    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-        guard let cell = collectionView.cellForItem(at: indexPath) as? GoalTagCollectionViewCell else { return }
-        cell.setUnselectState(with: goals[indexPath.row].isGoalEnd)
     }
 }
 


### PR DESCRIPTION
## What is this PR? 🔍
UI 버그 몇 가지 해결

## Key Changes 🔑
### 1. 회원가입 > 탭바 토큰 저장 로직 수정
- 기존 탭바로 넘어간 이후, 폰넘버가 저장됨
- 이로 인해 처음 회원가입/로그인 후 기록 탭에서 데이터 조회가 제대로 이뤄지지 않음
- 폰넘버 저장 이후 탭바로 넘어가도록 수정

### 2. 회고탭 목표 조회 로직 수정
+ 기존 페이지 상태값 유지 목적으로 목표 조회를 처음 viewDidLoad할 때만 되도록 설정해놨는데 목표 생성/삭제 되는 경우를 놓쳤더라구요..
+ view 다시 접근시 그냥 목표 조회 및 0번 페이지부터 기록 조회되도록 수정했습니다. 
+ 추가로 종료된 목표는 필터링해 제외시켰습니다

### 3. 목표/기록 생성 금액 0원인 경우 버튼 비활성화
+ 기존 금액 상관없이 값이 입력되기만 하면 버튼 활성화였는데, 서버 응답 이후 알게되는 상황인데 오류메시지 띄우는 것 없었더라구요...
+ 0원 이상 입력해야 버튼 활성화 되도록 수정했습니다. 

### 4. 회고탭/친구탭 컬렉션뷰 셀 deselectItem 메서드 버그 해결
+ 새로 view에 접근한 경우 view 리프레시를 시켰더니 기존 select item 값도 날라가버려서... 버그가...
+ didSelect 메서드에서 deselect도 시키도록 수정했습니다. 

## To Reviewers 📢
- 풀 받고 써주세요
+ 런칭 화이팅...~~~


## Related Issues ⛱
close #268 
close #269 
close #270