### PR TITLE
Style/#279: 작은 디바이스 대응 위한 레이아웃 재설정

### DIFF
--- a/POME/Global/Source/Calendar/CalendarSheetView.swift
+++ b/POME/Global/Source/Calendar/CalendarSheetView.swift
@@ -86,9 +86,10 @@ class CalendarSheetView: BaseView {
         }
         
         completeButton.snp.makeConstraints{
-            $0.bottom.centerX.equalToSuperview()
+            $0.centerX.equalToSuperview()
             $0.leading.equalToSuperview().offset(20)
             $0.height.equalTo(52)
+            $0.bottom.equalToSuperview().inset(35)
         }
     }
 }

--- a/POME/Global/Source/Calendar/CalendarSheetViewController.swift
+++ b/POME/Global/Source/Calendar/CalendarSheetViewController.swift
@@ -63,8 +63,7 @@ class CalendarSheetViewController: BaseSheetViewController {
     override func layout() {
         self.view.addSubview(mainView)
         mainView.snp.makeConstraints{
-            $0.top.leading.trailing.equalToSuperview()
-            $0.bottom.equalTo(self.view.safeAreaLayoutGuide)
+            $0.top.leading.trailing.bottom.equalToSuperview()
         }
     }
     

--- a/POME/Global/Source/Const.swift
+++ b/POME/Global/Source/Const.swift
@@ -16,6 +16,7 @@ struct Const{
 struct Device{
     static let WIDTH: CGFloat = UIScreen.main.bounds.size.width
     static let HEIGHT: CGFloat = UIScreen.main.bounds.size.height
+    static let isSmallDevice: Bool = Device.HEIGHT <= 736
 }
 
 struct Offset{

--- a/POME/Global/Source/Register/RegisterCommonView.swift
+++ b/POME/Global/Source/Register/RegisterCommonView.swift
@@ -27,7 +27,7 @@ class RegisterCommonTitleView: BaseView{
     
     init(title: String, subtitle: String){
         super.init(frame: .zero)
-        
+
         self.titleLabel.text = title
         self.subtitleLabel.text = subtitle
     }
@@ -42,7 +42,6 @@ class RegisterCommonTitleView: BaseView{
     }
     
     override func layout() {
-        
         titleLabel.snp.makeConstraints{
             $0.top.equalToSuperview().offset(12)
             $0.leading.equalToSuperview().offset(20)

--- a/POME/Global/Source/Register/RegisterSuccessView.swift
+++ b/POME/Global/Source/Register/RegisterSuccessView.swift
@@ -45,7 +45,7 @@ class RegisterSuccessView: BaseView {
             $0.leading.equalToSuperview().offset(20)
             $0.centerX.equalToSuperview()
             $0.height.equalTo(52)
-            $0.bottom.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(35)
             $0.top.greaterThanOrEqualTo(iconImage.snp.bottom)
         }
     }

--- a/POME/Global/Source/Register/RegisterSuccessViewController.swift
+++ b/POME/Global/Source/Register/RegisterSuccessViewController.swift
@@ -40,8 +40,7 @@ class RegisterSuccessViewController: UIViewController {
         
         mainView.snp.makeConstraints{
             $0.top.equalToSuperview().offset(Offset.VIEW_CONTROLLER_TOP)
-            $0.leading.trailing.equalToSuperview()
-            $0.bottom.equalTo(self.view.safeAreaLayoutGuide)
+            $0.leading.trailing.bottom.equalToSuperview()
         }
     }
     

--- a/POME/Presentation/ViewControllers/Goal/GoalContentViewController.swift
+++ b/POME/Presentation/ViewControllers/Goal/GoalContentViewController.swift
@@ -32,9 +32,8 @@ class GoalContentViewController: BaseViewController {
         
         self.view.addSubview(mainView)
         mainView.snp.makeConstraints{
-            $0.top.equalToSuperview().offset(Offset.VIEW_CONTROLLER_TOP)
-            $0.leading.trailing.equalToSuperview()
-            $0.bottom.equalTo(self.view.safeAreaLayoutGuide)
+            $0.top.equalTo(navigationView.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
         }
     }
     

--- a/POME/Presentation/ViewControllers/Goal/GoalDateViewController.swift
+++ b/POME/Presentation/ViewControllers/Goal/GoalDateViewController.swift
@@ -30,9 +30,8 @@ class GoalDateViewController: BaseViewController {
         
         self.view.addSubview(mainView)
         mainView.snp.makeConstraints{
-            $0.top.equalToSuperview().offset(Offset.VIEW_CONTROLLER_TOP)
-            $0.leading.trailing.equalToSuperview()
-            $0.bottom.equalTo(self.view.safeAreaLayoutGuide)
+            $0.top.equalTo(navigationView.snp.bottom)
+            $0.leading.bottom.trailing.equalToSuperview()
         }
     }
     

--- a/POME/Presentation/ViewControllers/Record/Register/RecordRegisterContentViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/RecordRegisterContentViewController.swift
@@ -59,9 +59,8 @@ class RecordRegisterContentViewController: BaseViewController {
         
         self.view.addSubview(mainView)
         mainView.snp.makeConstraints{
-            $0.top.equalToSuperview().offset(Offset.VIEW_CONTROLLER_TOP)
-            $0.leading.trailing.equalToSuperview()
-            $0.bottom.equalTo(self.view.safeAreaLayoutGuide)
+            $0.top.equalTo(navigationView.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
         }
     }
     

--- a/POME/Presentation/ViewControllers/Record/Register/RecordRegisterEmotionSelectViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/RecordRegisterEmotionSelectViewController.swift
@@ -29,9 +29,8 @@ class RecordRegisterEmotionSelectViewController: BaseViewController{
         
         self.view.addSubview(mainView)
         mainView.snp.makeConstraints{
-            $0.top.equalToSuperview().offset(Offset.VIEW_CONTROLLER_TOP)
-            $0.leading.trailing.equalToSuperview()
-            $0.bottom.equalTo(self.view.safeAreaLayoutGuide)
+            $0.top.equalTo(navigationView.snp.bottom)
+            $0.leading.trailing.bottom.equalToSuperview()
         }
     }
     

--- a/POME/Presentation/Views/Goal/GoalContentView.swift
+++ b/POME/Presentation/Views/Goal/GoalContentView.swift
@@ -86,6 +86,7 @@ class GoalContentView: BaseView {
         priceField.snp.makeConstraints{
             $0.top.equalTo(promiseField.snp.bottom)
             $0.leading.trailing.equalToSuperview()
+            $0.bottom.lessThanOrEqualTo(goalMakePublicView.snp.top).offset(10)
         }
         
         goalMakePublicView.snp.makeConstraints{
@@ -112,7 +113,7 @@ class GoalContentView: BaseView {
         completeButton.snp.makeConstraints{
             $0.leading.equalToSuperview().offset(20)
             $0.centerX.equalToSuperview()
-            $0.bottom.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(35)
             $0.height.equalTo(52)
         }
     }

--- a/POME/Presentation/Views/Goal/GoalDateView.swift
+++ b/POME/Presentation/Views/Goal/GoalDateView.swift
@@ -58,7 +58,7 @@ class GoalDateView: BaseView {
         }
         
         completButton.snp.makeConstraints{
-            $0.bottom.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(35)
             $0.leading.equalToSuperview().offset(20)
             $0.centerX.equalToSuperview()
             $0.height.equalTo(52)

--- a/POME/Presentation/Views/Record/Register/RecordRegisterContentView.swift
+++ b/POME/Presentation/Views/Record/Register/RecordRegisterContentView.swift
@@ -68,7 +68,7 @@ class RecordContentView: BaseView{
         }
         
         completeButton.snp.makeConstraints{
-            $0.bottom.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(35)
             $0.leading.equalToSuperview().offset(20)
             $0.centerX.equalToSuperview()
             $0.height.equalTo(52)
@@ -100,8 +100,7 @@ class RecordRegisterContentView: RecordContentView {
     
     override func setTopConstriant() {
         titleView.snp.makeConstraints{
-            $0.top.equalToSuperview().offset(12)
-            $0.leading.trailing.equalToSuperview()
+            $0.top.leading.trailing.equalToSuperview()
         }
         
         goalField.snp.makeConstraints{

--- a/POME/Presentation/Views/Record/Register/RecordRegisterEmotionSelectView.swift
+++ b/POME/Presentation/Views/Record/Register/RecordRegisterEmotionSelectView.swift
@@ -14,7 +14,7 @@ class RecordRegisterEmotionSelectView: BaseView {
                                          subtitle: "포미는 순간의 감정에 집중해 \n한번 기록된 감정은 바꿀 수 없어요")
     
     let emotionStackView = UIStackView().then{
-        $0.spacing = 40
+        $0.spacing = Device.isSmallDevice ? 32 : 40
         $0.axis = .vertical
     }
     
@@ -38,9 +38,9 @@ class RecordRegisterEmotionSelectView: BaseView {
         
         super.hierarchy()
         
-        self.addSubview(titleView)
-        self.addSubview(emotionStackView)
-        self.addSubview(completeButton)
+        addSubview(titleView)
+        addSubview(emotionStackView)
+        addSubview(completeButton)
         
         emotionStackView.addArrangedSubview(happyEmotionView)
         emotionStackView.addArrangedSubview(whatEmotionView)
@@ -50,17 +50,17 @@ class RecordRegisterEmotionSelectView: BaseView {
     override func layout() {
         
         titleView.snp.makeConstraints{
-            $0.top.equalToSuperview()
-            $0.leading.trailing.equalToSuperview()
+            $0.top.leading.trailing.equalToSuperview()
         }
         
         emotionStackView.snp.makeConstraints{
             $0.top.equalTo(titleView.snp.bottom).offset(41)
             $0.leading.equalToSuperview().offset(89)
+//            $0.bottom.lessThanOrEqualTo(completeButton.snp.top).inset(10)
         }
         
         completeButton.snp.makeConstraints{
-            $0.bottom.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(35)
             $0.leading.equalToSuperview().offset(20)
             $0.centerX.equalToSuperview()
             $0.height.equalTo(52)
@@ -76,7 +76,8 @@ extension RecordRegisterEmotionSelectView{
         var emotion: EmotionTag!
         
         private let imageBackView = UIView().then{
-            $0.layer.cornerRadius = 110 / 2
+            let imageSize: CGFloat = Device.isSmallDevice ? 90 : 110
+            $0.layer.cornerRadius = imageSize / 2
         }
         
         private let emotionImageView = UIImageView()
@@ -115,7 +116,8 @@ extension RecordRegisterEmotionSelectView{
         
         override func layout() {
             imageBackView.snp.makeConstraints{
-                $0.width.height.equalTo(110)
+                let size = Device.isSmallDevice ? 90 : 110
+                $0.width.height.equalTo(size)
                 $0.top.bottom.leading.equalToSuperview()
             }
             


### PR DESCRIPTION
## What is this PR? 🔍
아이폰 SE, 8 등 작은 디바이스 대응 위한 레이아웃 재설정

## Key Changes 🔑

### 1. Device 정적 프로퍼티 isSmallDevice 추가
+ 테스트 결과 8부터 레이아웃 문제가 발생하는 걸로 파악
+ 8의 높이 값은 736, SE는 이보다 더 작음
+ 736을 기준으로 해 isSmallDevice 여부 값 반환

### 2. CTA 버튼 기준 변경
+ 기존 safeArea를 하단 기준으로 설정했는데, SE, 8 등 홈버튼 있는 경우는 아예 바닥에 딱 붙어 버려서 safeArea 대신 수치 적용으로 변경했습니다. 

### 3. 기록/목표 생성 레이아웃
+ 타이틀 뷰 상단 기준이 수치로 되어있었는데, 노치가 있는 경우와 없는 경우 레이아웃 수치값이 달라져야 하기 때문에 수치 대신 navigationView를 기준으로 변경했습니다. 

## To Reviewers 📢
- 풀 받고 써주세요


## Related Issues ⛱
close #279