### PR TITLE
Refactor/#295: 회고탭 목표 조회/기록 조회 ViewModel + CleanArchitecture 적용

### DIFF
--- a/POME/Data/Repository/RecordRepository.swift
+++ b/POME/Data/Repository/RecordRepository.swift
@@ -10,6 +10,21 @@ import RxSwift
 
 class RecordRepository: RecordRepositoryInterface{
     
+    func getRecordInReview(goalId: Int, requestValue: GetRecordInReviewRequestModel) -> Observable<PageableResponseModel<RecordResponseModel>>{
+        let observable = Observable<PageableResponseModel<RecordResponseModel>>.create { observer -> Disposable in
+            let requestReference: () = RecordService.shared.getRecordsOfGoalAtReviewTab(id: goalId, request: requestValue){ response in
+                switch response {
+                case .success(let data):
+                    observer.onNext(data)
+                default:
+                    break
+                }
+            }
+            return Disposables.create(with: { requestReference })
+        }
+        return observable
+    }
+    
     func modifyRecord(id: Int, requestValue: RecordDTO) -> Observable<Int> {
         let observable = Observable<Int>.create { observer -> Disposable in
             let requestReference: () = RecordService.shared.modifyRecord(id: id, request: requestValue){ response in

--- a/POME/Data/Service/Foundation/MultiMoyaService.swift
+++ b/POME/Data/Service/Foundation/MultiMoyaService.swift
@@ -195,17 +195,17 @@ class MultiMoyaService: MoyaProvider<MultiTarget> {
     }
     
     func requestGenerateAccessToken(){
-        AuthService.shared.generateAccessToken{ response in
-            switch response{
-            case .success(let token):
-                print("LOG: SUCCESS requestGenerateAccessToken", token)
-                UserManager.token = token
-                break
-            default:
-                print("LOG: INVALID SUCCESS requestGenerateAccessToken")
-                self.requestGenerateAccessToken()
-            }
-        }
+//        AuthService.shared.generateAccessToken{ response in
+//            switch response{
+//            case .success(let token):
+//                print("LOG: SUCCESS requestGenerateAccessToken", token)
+//                UserManager.token = token
+//                break
+//            default:
+//                print("LOG: INVALID SUCCESS requestGenerateAccessToken")
+//                self.requestGenerateAccessToken()
+//            }
+//        }
     }
     
     private func addObserver() {

--- a/POME/Data/Service/Record/RecordRouter.swift
+++ b/POME/Data/Service/Record/RecordRouter.swift
@@ -14,7 +14,7 @@ enum RecordRouter: BaseRouter{
     case postRecord(request: GenerateRecordRequestModel)
     case getRecordsOfGoalByUser(id: Int, pageable: PageableModel)
     case getRecordsOfGoalByUserAtRecordTab(id: Int, pageable: PageableModel)    // 기록탭
-    case getRecordsOfGoalByUserAtReviewTab(id: Int, firstEmotion: Int?, secondEmotion: Int?, pageable: PageableModel)    // 회고탭
+    case getRecordsOfGoalByUserAtReviewTab(id: Int, request: GetRecordInReviewRequestModel)    // 회고탭
     case getNoSecondEmoRecords(id: Int)     // 일주일이 지났고, 두 번째 감정을 남겨야하는 기록 조회
     case postSecondEmotion(id: Int, param: RecordSecondEmotionRequestModel)
 }
@@ -28,7 +28,7 @@ extension RecordRouter{
         case .postRecord:                                       return HTTPMethodURL.POST.record
         case .getRecordsOfGoalByUser(let id, _):                return HTTPMethodURL.GET.recordOfGoal + "/\(id)"
         case .getRecordsOfGoalByUserAtRecordTab(let id, _):        return HTTPMethodURL.GET.recordOfGoal + "/\(id)/record-tab"
-        case .getRecordsOfGoalByUserAtReviewTab(let id, _, _, _):    return HTTPMethodURL.GET.recordOfGoal + "/\(id)/retrospection-tab"
+        case .getRecordsOfGoalByUserAtReviewTab(let id, _):    return HTTPMethodURL.GET.recordOfGoal + "/\(id)/retrospection-tab"
         case .getNoSecondEmoRecords(let id):                    return HTTPMethodURL.GET.noSecondEmotionRecords + "/\(id)"
         case .postSecondEmotion(let id, _):                     return HTTPMethodURL.POST.secondEmotion + "/\(id)" + "/second-emotion"
 
@@ -58,18 +58,16 @@ extension RecordRouter{
                                                                                                                "size" : pageable.size,
                                                                                                                "sort" : pageable.sort],
                                                                                                   encoding: URLEncoding.queryString)
-        case .getRecordsOfGoalByUserAtReviewTab(_, let firstEmotion,
-                                                let secondEmotion ,
-                                                let pageable):
+        case .getRecordsOfGoalByUserAtReviewTab(_, let request):
             
-            var parameter: [String: Any] = ["page" : pageable.page,
-                                            "size" : pageable.size,
-                                            "sort" : pageable.sort]
-            if(firstEmotion != nil){
-                parameter["first_emotion"] = firstEmotion
+            var parameter: [String: Any] = ["page" : request.pageable.page,
+                                            "size" : request.pageable.size,
+                                            "sort" : request.pageable.sort]
+            if(request.firstEmotion != nil){
+                parameter["first_emotion"] = request.firstEmotion
             }
-            if(secondEmotion != nil){
-                parameter["second_emotion"] = secondEmotion
+            if(request.secondEmotion != nil){
+                parameter["second_emotion"] = request.secondEmotion
             }
                                                                         return .requestParameters(parameters: parameter,
                                                                                                   encoding: URLEncoding.queryString)

--- a/POME/Data/Service/Record/RecordService.swift
+++ b/POME/Data/Service/Record/RecordService.swift
@@ -52,8 +52,15 @@ extension RecordService{
         }
     }
     
-    func getRecordsOfGoalAtReviewTab(id: Int, firstEmotion: Int?, secondEmotion: Int?, pageable: PageableModel, animate: Bool,completion: @escaping (NetworkResult<PageableResponseModel<RecordResponseModel>>) -> Void) {
-        provider.requestDecoded(RecordRouter.getRecordsOfGoalByUserAtReviewTab(id: id, firstEmotion: firstEmotion, secondEmotion: secondEmotion, pageable: pageable), animate: animate) { response in
+//    func getRecordsOfGoalAtReviewTab(id: Int, firstEmotion: Int?, secondEmotion: Int?, pageable: PageableModel, animate: Bool,completion: @escaping (NetworkResult<PageableResponseModel<RecordResponseModel>>) -> Void) {
+//        provider.requestDecoded(RecordRouter.getRecordsOfGoalByUserAtReviewTab(id: id, firstEmotion: firstEmotion, secondEmotion: secondEmotion, pageable: pageable), animate: animate) { response in
+//            completion(response)
+//        }
+//    }
+    
+    //CLEAN ARCHITECURE VER.
+    func getRecordsOfGoalAtReviewTab(id: Int, request: GetRecordInReviewRequestModel, completion: @escaping (NetworkResult<PageableResponseModel<RecordResponseModel>>) -> Void) {
+        provider.requestDecoded(RecordRouter.getRecordsOfGoalByUserAtReviewTab(id: id, request: request), animate: false) { response in
             completion(response)
         }
     }

--- a/POME/Domain/RepositoryInterface/RecordRepositoryInterface.swift
+++ b/POME/Domain/RepositoryInterface/RecordRepositoryInterface.swift
@@ -9,6 +9,7 @@ import Foundation
 import RxSwift
 
 protocol RecordRepositoryInterface{
+    func getRecordInReview(goalId: Int, requestValue: GetRecordInReviewRequestModel) -> Observable<PageableResponseModel<RecordResponseModel>>
     func modifyRecord(id: Int, requestValue: RecordDTO) -> Observable<Int>
     func generateRecord(requestValue: GenerateRecordRequestModel) -> Observable<Int>
     func deleteRecord()

--- a/POME/Domain/UseCase/Record/GetRecordInReviewUseCase.swift
+++ b/POME/Domain/UseCase/Record/GetRecordInReviewUseCase.swift
@@ -1,8 +1,33 @@
 //
-//  GetRecordUseCase.swift
+//  GetRecordInReviewUseCase.swift
 //  POME
 //
 //  Created by 박소윤 on 2023/03/28.
 //
 
 import Foundation
+import RxSwift
+
+struct GetRecordInReviewRequestModel{
+    let firstEmotion: Int?
+    let secondEmotion: Int?
+    let pageable: PageableModel
+}
+
+protocol GetRecordInReviewUseCaseInterface {
+    func execute(goalId: Int, requestValue: GetRecordInReviewRequestModel) -> Observable<PageableResponseModel<RecordResponseModel>>
+}
+
+final class GetRecordInReviewUseCase: GetRecordInReviewUseCaseInterface {
+
+    private let recordRepository: RecordRepositoryInterface
+
+    init(recordRepository: RecordRepositoryInterface = RecordRepository()) {
+        self.recordRepository = recordRepository
+    }
+
+    func execute(goalId: Int, requestValue: GetRecordInReviewRequestModel) -> Observable<PageableResponseModel<RecordResponseModel>> {
+        return recordRepository.getRecordInReview(goalId: goalId, requestValue: requestValue)
+        
+    }
+}

--- a/POME/Global/Resource/Extension/UICollectionView.swift
+++ b/POME/Global/Resource/Extension/UICollectionView.swift
@@ -25,8 +25,7 @@ extension UICollectionView{
         return cell
     }
     
-    final func cellForItem<T: BaseCollectionViewCell>(at indexPath: IndexPath, cellType: T.Type) -> T {
-        guard let cell = self.cellForItem(at: indexPath) as? T else { fatalError() }
-        return cell
+    final func cellForItem<T: BaseCollectionViewCell>(at indexPath: IndexPath, cellType: T.Type) -> T? {
+        self.cellForItem(at: indexPath) as? T
     }
 }

--- a/POME/Presentation/ViewControllers/Goal/GenerateGoalContentViewController.swift
+++ b/POME/Presentation/ViewControllers/Goal/GenerateGoalContentViewController.swift
@@ -13,13 +13,9 @@ enum GenerateGoalStatus: String{
     case duplicateGoal = "G0004" //Goal 생성 시, 이미 등록된 Goal-Category 명으로 등록한 경우
 }
 
-class GenerateGoalContentViewController: BaseViewController {
+final class GenerateGoalContentViewController: BaseViewController {
     
-    private let mainView = GoalContentView()
-    private let viewModel = GenerateGoalContentViewModel()
     private let goalDateRange: GoalDateDTO
-    
-    //MARK: - Override
     
     init(goalDateRange: GoalDateDTO){
         self.goalDateRange = goalDateRange
@@ -30,9 +26,12 @@ class GenerateGoalContentViewController: BaseViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    private let mainView = GoalContentView()
+    private let viewModel = GenerateGoalContentViewModel()
+    
     override func style(){
         super.style()
-        self.setEtcButton(title: "닫기")
+        setEtcButton(title: "닫기")
     }
     
     override func layout(){
@@ -102,8 +101,8 @@ class GenerateGoalContentViewController: BaseViewController {
     
     private func closeButtonDidClicked(){
         ImageAlert.quitRecord.generateAndShow(in: self).do{
-            $0.completion = {
-                self.navigationController?.popToRootViewController(animated: true)
+            $0.completion = { [weak self] in
+                self?.navigationController?.popToRootViewController(animated: true)
             }
         }
     }

--- a/POME/Presentation/ViewControllers/Goal/GenerateGoalDateViewController.swift
+++ b/POME/Presentation/ViewControllers/Goal/GenerateGoalDateViewController.swift
@@ -16,7 +16,7 @@ enum CalendarDate: Int{
     case end = 200
 }
 
-class GenerateGoalDateViewController: BaseViewController {
+final class GenerateGoalDateViewController: BaseViewController {
     
     private let mainView = GenerateGoalDateView()
     private let viewModel = GenerateGoalDateViewModel()
@@ -116,6 +116,6 @@ class GenerateGoalDateViewController: BaseViewController {
     
     private func willMoveGoalContentViewController(dateRange: GoalDateDTO){
         let vc = GenerateGoalContentViewController(goalDateRange: dateRange)
-        self.navigationController?.pushViewController(vc, animated: true)
+        navigationController?.pushViewController(vc, animated: true)
     }
 }

--- a/POME/Presentation/ViewControllers/Record/Register/GenerateRecordViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/GenerateRecordViewController.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class GenerateRecordViewController: Recordable{
+final class GenerateRecordViewController: Recordable{
     
     init(goal: GoalResponseModel){
         super.init(recordType: .generate,

--- a/POME/Presentation/ViewControllers/Record/Register/GoalSelectSheetViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/GoalSelectSheetViewController.swift
@@ -9,19 +9,7 @@ import UIKit
 
 class GoalSelectSheetViewController: BaseSheetViewController {
     
-    //MARK: - Properties
-    
-    var completion: ((Int) -> ())! //TODO: WILL DELETE
-    
-    private var goals: [GoalResponseModel]!
-    private let mainView = GoalSelectSheetView()
-    private var viewModel: GoalSelectViewModel!
-    //MARK: - LifeCycle
-    
-    init(data goals: [GoalResponseModel]){ //TODO: WILL DELETE
-        self.goals = goals
-        super.init(type: .category)
-    }
+    private let viewModel: GoalSelectViewModel
     
     init(viewModel: RecordableViewModel){
         self.viewModel = viewModel
@@ -32,13 +20,15 @@ class GoalSelectSheetViewController: BaseSheetViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    private let mainView = GoalSelectSheetView()
+    
     override func viewWillAppear(_ animated: Bool) {
         mainView.goalTableView.reloadData()
     }
     
     override func initialize(){
         super.initialize()
-        mainView.exitButton.addTarget(self, action: #selector(exitButtonDidClicked), for: .touchUpInside)
+        mainView.exitButton.addTarget(self, action: #selector(exitButtonDidTapped), for: .touchUpInside)
         setTableViewDelegate()
     }
     
@@ -57,7 +47,7 @@ class GoalSelectSheetViewController: BaseSheetViewController {
         }
     }
     
-    @objc func exitButtonDidClicked(){
+    @objc private func exitButtonDidTapped(){
         dismiss(animated: true)
     }
 }
@@ -69,7 +59,7 @@ extension GoalSelectSheetViewController: UITableViewDelegate, UITableViewDataSou
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        return tableView.dequeueReusableCell(for: indexPath, cellType: RecordCategoryTableViewCell.self).then{
+        tableView.dequeueReusableCell(for: indexPath, cellType: RecordCategoryTableViewCell.self).then{
             $0.nameLabel.text = viewModel.getGoalTitle(at: indexPath.row)
         }
     }

--- a/POME/Presentation/ViewControllers/Record/Register/GoalSelectSheetViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/GoalSelectSheetViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class GoalSelectSheetViewController: BaseSheetViewController {
+final class GoalSelectSheetViewController: BaseSheetViewController {
     
     private let viewModel: GoalSelectViewModel
     

--- a/POME/Presentation/ViewControllers/Record/Register/ModifyRecordViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/ModifyRecordViewController.swift
@@ -7,12 +7,6 @@
 
 import Foundation
 
-struct TestData{
-    static let testRecordData = RecordResponseModel(id: 1076, nickname: "쑤야아아아아", usePrice: 1000, useDate: "2023.03.21", createdAt: "2023-03-21T14:17:04.939691", useComment: "반지 샀다ㅎ", oneLineMind: "목표를 달성하자", emotionResponse: EmotionResponseModel(firstEmotion: 0, secondEmotion: nil, friendEmotions: []))
-    
-    static let testGoalData = GoalResponseModel(endDate: "2023.04.06", id: 1075, isEnd: false, isPublic: true, name: "목표 설정", nickname: "쑤야아아아아", oneLineMind: "목표를 달성하자", price: 100000, startDate: "2023.03.31", usePrice: 1000)
-}
-
 class ModifyRecordViewController: Recordable{
     
     private let record: RecordResponseModel

--- a/POME/Presentation/ViewControllers/Record/Register/ModifyRecordViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/ModifyRecordViewController.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-class ModifyRecordViewController: Recordable{
+final class ModifyRecordViewController: Recordable{
     
     private let record: RecordResponseModel
     

--- a/POME/Presentation/ViewControllers/Record/Register/RecordFirstEmotionViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/RecordFirstEmotionViewController.swift
@@ -9,7 +9,7 @@ import Foundation
 import RxSwift
 import RxCocoa
 
-class RecordFirstEmotionViewController: BaseViewController{
+final class RecordFirstEmotionViewController: BaseViewController{
     
     private let record: RecordDTO
     

--- a/POME/Presentation/ViewControllers/Review/FriendReactionSheetTestViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/FriendReactionSheetTestViewController.swift
@@ -85,7 +85,7 @@ extension FriendReactionSheetTestViewController: UICollectionViewDelegate, UICol
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         switch getCollectionViewType(tag: collectionView.tag){
         case .reactionType:         return 7
-        case .friendReaction:   return viewModel.getFriendsReactionCount()
+        case .friendReaction:       return viewModel.getFriendsReactionCount()
         }
     }
     
@@ -129,7 +129,7 @@ extension FriendReactionSheetTestViewController: UICollectionViewDelegate, UICol
         if (getCollectionViewType(tag: collectionView.tag) != .reactionType) {
             return
         }
-        closure(collectionView.cellForItem(at: indexPath, cellType: ReactionTypeCollectionViewCell.self))
+        closure(collectionView.cellForItem(at: indexPath, cellType: ReactionTypeCollectionViewCell.self)!)
     }
     
 }

--- a/POME/Presentation/ViewControllers/Review/ReviewTestViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewTestViewController.swift
@@ -75,7 +75,7 @@ class ReviewTestViewController: BaseTabViewController{
 extension ReviewTestViewController: UICollectionViewDelegate, UICollectionViewDataSource{
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        viewModel.getGoalsCount()
+        viewModel.goalsCount
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -91,7 +91,7 @@ extension ReviewTestViewController: UITableViewDelegate, UITableViewDataSource{
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if(section == 0){
-            return viewModel.getRecordsCount() + COUNT_OF_NOT_RECORD_CELL
+            return viewModel.recordsCount + COUNT_OF_NOT_RECORD_CELL
         }else if(section == 1 && isPaging && viewModel.hasNextPage()){
             return 1
         }else{
@@ -127,7 +127,7 @@ extension ReviewTestViewController: UITableViewDelegate, UITableViewDataSource{
     
     private func getGoalDetailTableViewCell(indexPath: IndexPath) -> GoalDetailTableViewCell{
         mainView.tableView.dequeueReusableCell(for: indexPath, cellType: GoalDetailTableViewCell.self).then{
-            viewModel.isGoalEmpty() ? $0.bindingEmptyData() : $0.bindingData(goal: viewModel.getSelectGoal())
+            viewModel.isGoalEmpty ? $0.bindingEmptyData() : $0.bindingData(goal: viewModel.selectedGoal)
         }
     }
     

--- a/POME/Presentation/ViewControllers/Review/ReviewTestViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewTestViewController.swift
@@ -17,8 +17,9 @@ class ReviewTestViewController: BaseTabViewController{
     
     private var isPaging: Bool = false
     
+    private let COUNT_OF_NOT_RECORD_CELL = 3 //record 이외 UI 구성하는 cell 3개 존재
     private let mainView = ReviewView()
-    private let viewModel = ReviewViewModel()
+    private lazy var viewModel = ReviewViewModel(uiRelatedCellCount: COUNT_OF_NOT_RECORD_CELL)
     private lazy var firstEmotionFilterBottomSheet = EmotionFilterTestSheetViewController.generateFirstEmotionFilter(viewModel: viewModel)
     private lazy var secondEmotionFilterBottomSheet = EmotionFilterTestSheetViewController.generateSecondEmotionFilter(viewModel: viewModel)
     
@@ -55,8 +56,10 @@ class ReviewTestViewController: BaseTabViewController{
         
         output.initializeEmotionFilter
             .drive(onNext: {
-                filteringCell?.firstEmotionFilter.setFilterDefaultState()
-                filteringCell?.secondEmotionFilter.setFilterDefaultState()
+                filteringCell?.do{
+                    $0.firstEmotionFilter.setFilterDefaultState()
+                    $0.secondEmotionFilter.setFilterDefaultState()
+                }
             }).disposed(by: disposeBag)
     }
     
@@ -88,7 +91,7 @@ extension ReviewTestViewController: UITableViewDelegate, UITableViewDataSource{
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if(section == 0){
-            return viewModel.getRecordsCount() + 3 //record 이외 UI 구성하는 cell 3개 존재
+            return viewModel.getRecordsCount() + COUNT_OF_NOT_RECORD_CELL
         }else if(section == 1 && isPaging && viewModel.hasNextPage()){
             return 1
         }else{
@@ -172,29 +175,29 @@ extension ReviewTestViewController: RecordCellDelegate{
 }
 
 extension ReviewTestViewController{
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        let offsetY = scrollView.contentOffset.y
-        let contentHeight = scrollView.contentSize.height
-        let height = scrollView.frame.height
-        
-        if offsetY > (contentHeight - height) {
-            if isPaging == false && viewModel.hasNextPage() {
-                beginPaging()
-            }
-        }
-    }
-    
-    private func beginPaging(){
-        
-        isPaging = true
-        viewModel.requestNextPage()
-        
-        DispatchQueue.main.async { [self] in
-            mainView.tableView.reloadSections(IndexSet(integer: 1), with: .none)
-        }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-//            self.requestGetRecords()
-        }
-    }
+//    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+//        let offsetY = scrollView.contentOffset.y
+//        let contentHeight = scrollView.contentSize.height
+//        let height = scrollView.frame.height
+//
+//        if offsetY > (contentHeight - height) {
+//            if isPaging == false && viewModel.hasNextPage() {
+//                beginPaging()
+//            }
+//        }
+//    }
+//
+//    private func beginPaging(){
+//
+//        isPaging = true
+//        viewModel.requestNextPage()
+//
+//        DispatchQueue.main.async { [self] in
+//            mainView.tableView.reloadSections(IndexSet(integer: 1), with: .none)
+//        }
+//
+//        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+////            self.requestGetRecords()
+//        }
+//    }
 }

--- a/POME/Presentation/ViewControllers/Review/ReviewTestViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewTestViewController.swift
@@ -19,7 +19,7 @@ class ReviewTestViewController: BaseTabViewController{
     
     private let COUNT_OF_NOT_RECORD_CELL = 3 //record 이외 UI 구성하는 cell 3개 존재
     private let mainView = ReviewView()
-    private lazy var viewModel = ReviewViewModel(uiRelatedCellCount: COUNT_OF_NOT_RECORD_CELL)
+    private lazy var viewModel = ReviewViewModel(regardlessOfRecordCount: COUNT_OF_NOT_RECORD_CELL)
     private lazy var firstEmotionFilterBottomSheet = EmotionFilterTestSheetViewController.generateFirstEmotionFilter(viewModel: viewModel)
     private lazy var secondEmotionFilterBottomSheet = EmotionFilterTestSheetViewController.generateSecondEmotionFilter(viewModel: viewModel)
     

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -327,26 +327,26 @@ extension ReviewViewController{
     }
 
     private func requestGetRecords(){
-        let goalId = goals[currentGoal].id
-        let loadingViewAnimate = page == 0 ? true : false
-        RecordService.shared.getRecordsOfGoalAtReviewTab(id: goalId,
-                                                         firstEmotion: filterController.0,
-                                                         secondEmotion: filterController.1,
-                                                         pageable: PageableModel(page: page),
-                                                         animate: loadingViewAnimate){ response in
-            switch response {
-            case .success(let data):
-                print("LOG: success requestGetRecords", data)
-                self.processResponseGetRecords(data: data)
-                return
-            default:
-                print("LOG: fail requestGetRecords", response)
-                NetworkAlert.show(in: self){ [weak self] in
-                    self?.requestGetRecords()
-                }
-                break
-            }
-        }
+//        let goalId = goals[currentGoal].id
+//        let loadingViewAnimate = page == 0 ? true : false
+//        RecordService.shared.getRecordsOfGoalAtReviewTab(id: goalId,
+//                                                         firstEmotion: filterController.0,
+//                                                         secondEmotion: filterController.1,
+//                                                         pageable: PageableModel(page: page),
+//                                                         animate: loadingViewAnimate){ response in
+//            switch response {
+//            case .success(let data):
+//                print("LOG: success requestGetRecords", data)
+//                self.processResponseGetRecords(data: data)
+//                return
+//            default:
+//                print("LOG: fail requestGetRecords", response)
+//                NetworkAlert.show(in: self){ [weak self] in
+//                    self?.requestGetRecords()
+//                }
+//                break
+//            }
+//        }
     }
     
     private func processResponseGetRecords(data: PageableResponseModel<RecordResponseModel>){

--- a/POME/Presentation/ViewModel/Goal/GenerateGoalContentViewModel.swift
+++ b/POME/Presentation/ViewModel/Goal/GenerateGoalContentViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import RxSwift
 import RxCocoa
 
-class GenerateGoalContentViewModel{
+final class GenerateGoalContentViewModel{
     
     private let generateGoalUseCase: GenerateGoalUseCase
     

--- a/POME/Presentation/ViewModel/Goal/GenerateGoalDateViewModel.swift
+++ b/POME/Presentation/ViewModel/Goal/GenerateGoalDateViewModel.swift
@@ -10,7 +10,7 @@ import RxSwift
 import RxCocoa
 import RxGesture
 
-class GenerateGoalDateViewModel{
+final class GenerateGoalDateViewModel{
     
     private let startDateSubject = PublishSubject<String>()
     private let endDateSubject = PublishSubject<String>()

--- a/POME/Presentation/ViewModel/Record/Register/GenerateRecordViewModel.swift
+++ b/POME/Presentation/ViewModel/Record/Register/GenerateRecordViewModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 import RxCocoa
 
-class GenerateRecordViewModel: RecordableViewModel{
+final class GenerateRecordViewModel: RecordableViewModel{
     
     private let generateRecordUseCase: ModifyRecordUseCaseInterface
     

--- a/POME/Presentation/ViewModel/Record/Register/ModifyRecordViewModel.swift
+++ b/POME/Presentation/ViewModel/Record/Register/ModifyRecordViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import RxSwift
 import RxCocoa
 
-class ModifyRecordViewModel: RecordableViewModel, RecordButtonControl{
+final class ModifyRecordViewModel: RecordableViewModel, RecordButtonControl{
     
     private let modifyRecordUseCase: ModifyRecordUseCaseInterface
     private let recordId: Int

--- a/POME/Presentation/ViewModel/Record/Register/RecordFirstEmotionViewModel.swift
+++ b/POME/Presentation/ViewModel/Record/Register/RecordFirstEmotionViewModel.swift
@@ -10,7 +10,7 @@ import RxSwift
 import RxCocoa
 import RxGesture
 
-class RecordFirstEmotionViewModel{
+final class RecordFirstEmotionViewModel{
     
     private let generateRecordUseCase: GenerateRecordUseCase
     private let emotionSubject = PublishSubject<Int>()

--- a/POME/Presentation/ViewModel/Review/ReviewViewModel.swift
+++ b/POME/Presentation/ViewModel/Review/ReviewViewModel.swift
@@ -28,7 +28,6 @@ class ReviewViewModel: BaseViewModel{
     
     private typealias FilteringCondition = (Int?, Int?)
     
-    private var selectedGoal: Int!
     private var goals = [GoalResponseModel]()
     private var records = [RecordResponseModel]()
     private lazy var dataIndex: (Int) -> Int = { row in row - self.uiRelatedCellCount }

--- a/POME/Presentation/ViewModel/Review/ReviewViewModel.swift
+++ b/POME/Presentation/ViewModel/Review/ReviewViewModel.swift
@@ -11,13 +11,16 @@ import RxCocoa
 
 class ReviewViewModel: BaseViewModel{
     
+    private let uiRelatedCellCount: Int
     private let getGoalsUseCase: GetGoalUseCaseInterface
     private let getRecordsUseCase: GetGoalUseCaseInterface
     private let deleteRecordUseCase: GetGoalUseCaseInterface
     
-    init(getGoalsUseCase: GetGoalUseCaseInterface = GetGoalUseCase(),
+    init(uiRelatedCellCount: Int,
+         getGoalsUseCase: GetGoalUseCaseInterface = GetGoalUseCase(),
          getRecordsUseCase: GetGoalUseCaseInterface = GetGoalUseCase(),
          deleteRecordUseCase: GetGoalUseCaseInterface = GetGoalUseCase()){
+        self.uiRelatedCellCount = uiRelatedCellCount
         self.getGoalsUseCase = getGoalsUseCase
         self.getRecordsUseCase = getRecordsUseCase
         self.deleteRecordUseCase = deleteRecordUseCase
@@ -28,8 +31,8 @@ class ReviewViewModel: BaseViewModel{
     private var selectedGoal: Int!
     private var goals = [GoalResponseModel]()
     private var records = [RecordResponseModel]()
+    private lazy var dataIndex: (Int) -> Int = { row in row - self.uiRelatedCellCount }
     
-    private let dataIndex: (Int) -> Int = { row in row - 3 }
     private let selectGoalSubject = BehaviorSubject<Int>(value: 0)
     private let filteringConditionSubject = BehaviorSubject<(Int?, Int?)>(value: (nil, nil))
     
@@ -83,10 +86,7 @@ extension ReviewViewModel{
     func viewDidLoad(){
         
     }
-    
-    func viewWillAppear(){
-        //목표 조회 api 호출
-    }
+
     
     func selectGoal(at index: Int){
         selectGoalSubject.onNext(index)

--- a/POME/Presentation/ViewModel/Review/ReviewViewModel.swift
+++ b/POME/Presentation/ViewModel/Review/ReviewViewModel.swift
@@ -26,14 +26,14 @@ class ReviewViewModel: BaseViewModel{
         self.deleteRecordUseCase = deleteRecordUseCase
     }
     
-    private typealias FilteringCondition = (Int?, Int?)
+    private typealias FilteringCondition = (first: Int?, second: Int?)
     
     private var goals = [GoalResponseModel]()
     private var records = [RecordResponseModel]()
     private lazy var dataIndex: (Int) -> Int = { row in row - self.regardlessOfRecordCount }
     
     private let selectGoalSubject = BehaviorSubject<Int>(value: 0)
-    private let filteringConditionSubject = BehaviorSubject<(Int?, Int?)>(value: (nil, nil))
+    private let filteringConditionSubject = BehaviorSubject<FilteringCondition>(value: (nil, nil))
     
     struct Input{
         
@@ -49,21 +49,21 @@ class ReviewViewModel: BaseViewModel{
     func transform(_ input: Input) -> Output{
         
         let firstEmotionState = filteringConditionSubject
-            .compactMap{ $0.0 }
+            .compactMap{ $0.first }
             .map{
                 EmotionTag(rawValue: $0)
             }.compactMap{ $0 }
             .asDriver(onErrorJustReturn: .default)
         
         let secondEmotionState = filteringConditionSubject
-            .compactMap{ $0.1 }
+            .compactMap{ $0.second }
             .map{
                 EmotionTag(rawValue: $0)
             }.compactMap{ $0 }
             .asDriver(onErrorJustReturn: .default)
         
         let initializeEmotionFilter = filteringConditionSubject
-            .filter{ $0.0 == nil && $0.1 == nil}
+            .filter{ $0.first == nil && $0.second == nil}
             .map{ _ in Void() }
             .asDriver(onErrorJustReturn: Void())
         
@@ -118,7 +118,7 @@ extension ReviewViewModel{
     }
     
     var goalsCount: Int{
-        goals.count == 0 ? 1 : goals.count
+        isGoalEmpty ? 1 : goals.count
     }
     
     var recordsCount: Int{

--- a/POME/Presentation/ViewModel/Review/ReviewViewModel.swift
+++ b/POME/Presentation/ViewModel/Review/ReviewViewModel.swift
@@ -11,16 +11,16 @@ import RxCocoa
 
 class ReviewViewModel: BaseViewModel{
     
-    private let uiRelatedCellCount: Int
+    private let regardlessOfRecordCount: Int
     private let getGoalsUseCase: GetGoalUseCaseInterface
     private let getRecordsUseCase: GetGoalUseCaseInterface
     private let deleteRecordUseCase: GetGoalUseCaseInterface
     
-    init(uiRelatedCellCount: Int,
+    init(regardlessOfRecordCount: Int,
          getGoalsUseCase: GetGoalUseCaseInterface = GetGoalUseCase(),
          getRecordsUseCase: GetGoalUseCaseInterface = GetGoalUseCase(),
          deleteRecordUseCase: GetGoalUseCaseInterface = GetGoalUseCase()){
-        self.uiRelatedCellCount = uiRelatedCellCount
+        self.regardlessOfRecordCount = regardlessOfRecordCount
         self.getGoalsUseCase = getGoalsUseCase
         self.getRecordsUseCase = getRecordsUseCase
         self.deleteRecordUseCase = deleteRecordUseCase
@@ -30,7 +30,7 @@ class ReviewViewModel: BaseViewModel{
     
     private var goals = [GoalResponseModel]()
     private var records = [RecordResponseModel]()
-    private lazy var dataIndex: (Int) -> Int = { row in row - self.uiRelatedCellCount }
+    private lazy var dataIndex: (Int) -> Int = { row in row - self.regardlessOfRecordCount }
     
     private let selectGoalSubject = BehaviorSubject<Int>(value: 0)
     private let filteringConditionSubject = BehaviorSubject<(Int?, Int?)>(value: (nil, nil))

--- a/POME/Presentation/ViewModel/Review/ReviewViewModel.swift
+++ b/POME/Presentation/ViewModel/Review/ReviewViewModel.swift
@@ -77,36 +77,32 @@ class ReviewViewModel: BaseViewModel{
 
 extension ReviewViewModel{
     
-    
-    /*
-     상단에서 아래로 스와이플 할 경우에만 데이터 reload 시키는 건 어떤지..?
-     */
-    
     func viewDidLoad(){
         
     }
-
     
+    func updateData(){
+        
+    }
+
     func selectGoal(at index: Int){
         selectGoalSubject.onNext(index)
     }
     
     func filterFirstEmotion(id: Int){
-        let current = getCurrentFilteringCondition()
-        changeFilteringCondition(first: id, second: current.1)
+        changeFilteringCondition(first: id, second: filteringCondition.1)
     }
     
     func filterSecondEmotion(id: Int){
-        let current = getCurrentFilteringCondition()
-        changeFilteringCondition(first: current.0, second: id)
+        changeFilteringCondition(first: filteringCondition.0, second: id)
     }
     
     func initializeFilterCondtion(){
         changeFilteringCondition(first: nil, second: nil)
     }
     
-    private func getCurrentFilteringCondition() -> FilteringCondition{
-        return try! filteringConditionSubject.value()
+    private var filteringCondition: FilteringCondition{
+        try! filteringConditionSubject.value()
     }
     
     private func changeFilteringCondition(first: Int?, second: Int?){
@@ -117,15 +113,15 @@ extension ReviewViewModel{
         
     }
     
-    func isGoalEmpty() -> Bool{
+    var isGoalEmpty: Bool{
         goals.count == 0
     }
     
-    func getGoalsCount() -> Int{
+    var goalsCount: Int{
         goals.count == 0 ? 1 : goals.count
     }
     
-    func getRecordsCount() -> Int{
+    var recordsCount: Int{
         records.count
     }
     
@@ -133,8 +129,12 @@ extension ReviewViewModel{
         records[dataIndex(index)]
     }
     
-    func getSelectGoal() -> GoalResponseModel{
-        goals[selectedGoal]
+    var selectedGoal: GoalResponseModel{
+        goals[selectedGoalIndex]
+    }
+    
+    var selectedGoalIndex: Int{
+        try! selectGoalSubject.value()
     }
     
     func hasNextPage() -> Bool{


### PR DESCRIPTION
## What is this PR? 🔍
회고탭 목표 조회/기록 조회 ViewModel + CleanArchitecture 적용

## Key Changes 🔑

### 1. 성능 최적화 위한 일부 클래스들 final 키워드 선언

### 2. 회고탭 목표 조회/기록 조회 API 연결 
+ ViewModel 활용해 데이터 바인딩 되도록 리팩토링 진행했습니다. 

## To Reviewers 📢
- 페이징 조회가 아직 ViewModel 활용 리팩토링 적용이 안됐는데, 이것도 얼릉 마무리를 해보도록 하겠습니다. 


## Related Issues ⛱
#295