### PR TITLE
Refactor/#295: 회고탭 기록 수정 / 삭제 ViewModel + RxSwift + Clean Architecture로 활용 리팩토링

### DIFF
--- a/POME/Data/Repository/RecordRepository.swift
+++ b/POME/Data/Repository/RecordRepository.swift
@@ -55,7 +55,18 @@ class RecordRepository: RecordRepositoryInterface{
         return observable
     }
 
-    func deleteRecord() {
-
+    func deleteRecord(requestValue: DeleteRecordRequestModel) -> Observable<BaseResponseStaus>{
+        let observable = Observable<BaseResponseStaus>.create { observer -> Disposable in
+            let requestReference: () = RecordService.shared.deleteRecord(id: requestValue.recordId) { response in
+                switch response {
+                case .success:
+                    observer.onNext(.success)
+                default:
+                    break
+                }
+            }
+            return Disposables.create(with: { requestReference })
+        }
+        return observable
     }
 }

--- a/POME/Data/Repository/RecordRepository.swift
+++ b/POME/Data/Repository/RecordRepository.swift
@@ -25,12 +25,12 @@ class RecordRepository: RecordRepositoryInterface{
         return observable
     }
     
-    func modifyRecord(id: Int, requestValue: RecordDTO) -> Observable<Int> {
-        let observable = Observable<Int>.create { observer -> Disposable in
+    func modifyRecord(id: Int, requestValue: RecordDTO) -> Observable<RecordResponseModel> {
+        let observable = Observable<RecordResponseModel>.create { observer -> Disposable in
             let requestReference: () = RecordService.shared.modifyRecord(id: id, request: requestValue){ response in
                 switch response {
-                case .success:
-                    observer.onNext(200)
+                case .success(let data):
+                    observer.onNext(data)
                 default:
                     break
                 }

--- a/POME/Domain/RepositoryInterface/RecordRepositoryInterface.swift
+++ b/POME/Domain/RepositoryInterface/RecordRepositoryInterface.swift
@@ -10,7 +10,7 @@ import RxSwift
 
 protocol RecordRepositoryInterface{
     func getRecordInReview(goalId: Int, requestValue: GetRecordInReviewRequestModel) -> Observable<PageableResponseModel<RecordResponseModel>>
-    func modifyRecord(id: Int, requestValue: RecordDTO) -> Observable<Int>
+    func modifyRecord(id: Int, requestValue: RecordDTO) -> Observable<RecordResponseModel>
     func generateRecord(requestValue: GenerateRecordRequestModel) -> Observable<Int>
     func deleteRecord(requestValue: DeleteRecordRequestModel) -> Observable<BaseResponseStaus>
 }

--- a/POME/Domain/RepositoryInterface/RecordRepositoryInterface.swift
+++ b/POME/Domain/RepositoryInterface/RecordRepositoryInterface.swift
@@ -12,5 +12,5 @@ protocol RecordRepositoryInterface{
     func getRecordInReview(goalId: Int, requestValue: GetRecordInReviewRequestModel) -> Observable<PageableResponseModel<RecordResponseModel>>
     func modifyRecord(id: Int, requestValue: RecordDTO) -> Observable<Int>
     func generateRecord(requestValue: GenerateRecordRequestModel) -> Observable<Int>
-    func deleteRecord()
+    func deleteRecord(requestValue: DeleteRecordRequestModel) -> Observable<BaseResponseStaus>
 }

--- a/POME/Domain/UseCase/Record/DeleteRecordUseCase.swift
+++ b/POME/Domain/UseCase/Record/DeleteRecordUseCase.swift
@@ -6,3 +6,31 @@
 //
 
 import Foundation
+import RxSwift
+
+enum BaseResponseStaus{
+    case success
+    case fail
+}
+
+struct DeleteRecordRequestModel{
+    let recordId: Int
+}
+
+protocol DeleteRecordUseCaseInterface {
+    func execute(requestValue: DeleteRecordRequestModel) -> Observable<BaseResponseStaus>
+}
+
+final class DeleteRecordUseCase: DeleteRecordUseCaseInterface {
+
+    private let recordRepository: RecordRepositoryInterface
+
+    init(recordRepository: RecordRepositoryInterface = RecordRepository()) {
+        self.recordRepository = recordRepository
+    }
+
+    func execute(requestValue: DeleteRecordRequestModel) -> Observable<BaseResponseStaus> {
+        return recordRepository.deleteRecord(requestValue: requestValue)
+        
+    }
+}

--- a/POME/Domain/UseCase/Record/ModifyRecordUseCase.swift
+++ b/POME/Domain/UseCase/Record/ModifyRecordUseCase.swift
@@ -9,7 +9,7 @@ import Foundation
 import RxSwift
 
 protocol ModifyRecordUseCaseInterface {
-    func execute(recordId: Int, requestValue: RecordDTO) -> Observable<Int>
+    func execute(recordId: Int, requestValue: RecordDTO) -> Observable<RecordResponseModel>
 }
 
 final class ModifyRecordUseCase: ModifyRecordUseCaseInterface {
@@ -20,7 +20,7 @@ final class ModifyRecordUseCase: ModifyRecordUseCaseInterface {
         self.recordRepository = recordRepository
     }
 
-    func execute(recordId: Int, requestValue: RecordDTO) -> Observable<Int>{
+    func execute(recordId: Int, requestValue: RecordDTO) -> Observable<RecordResponseModel>{
         return recordRepository.modifyRecord(id: recordId, requestValue: requestValue)
     }
 }

--- a/POME/Global/Source/Sheet/BaseSheetViewController.swift
+++ b/POME/Global/Source/Sheet/BaseSheetViewController.swift
@@ -76,7 +76,7 @@ class BaseSheetViewController: UIViewController, UIViewControllerTransitioningDe
     }
     
     @discardableResult
-    func loadAndShowBottomSheet(in viewController: UIViewController) -> Self{
+    func show(in viewController: UIViewController) -> Self{
         self.loadViewIfNeeded()
         self.viewController = viewController
         viewController.present(self, animated: true)

--- a/POME/Global/Source/TabBar/TabBarController.swift
+++ b/POME/Global/Source/TabBar/TabBarController.swift
@@ -55,7 +55,7 @@ class TabBarController: UITabBarController {
     func setTabBarItems(){
         
         let tabs = [UINavigationController(rootViewController: recordViewController),
-                    UINavigationController(rootViewController: ReviewViewController(btnImage: UIImage())),
+                    UINavigationController(rootViewController: ReviewTestViewController(btnImage: UIImage())),
                     UINavigationController(rootViewController: FriendViewController(btnImage: Image.addPeople)),
                     UINavigationController(rootViewController: MyPageViewController(btnImage: Image.setting))]
         

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -436,7 +436,7 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Frie
     
     func presentReactionSheet(indexPath: IndexPath) {
         let data = records[dataIndexBy(indexPath)].friendReactions
-        FriendReactionSheetTestViewController(reactions: data).loadAndShowBottomSheet(in: self)
+        FriendReactionSheetTestViewController(reactions: data).show(in: self)
     }
     
     func presentEtcActionSheet(indexPath: IndexPath) {

--- a/POME/Presentation/ViewControllers/Goal/GenerateGoalContentViewController.swift
+++ b/POME/Presentation/ViewControllers/Goal/GenerateGoalContentViewController.swift
@@ -115,6 +115,6 @@ final class GenerateGoalContentViewController: BaseViewController {
     private func processResponseDuplicateGoal(){
         RecordBottomSheetViewController(Image.flagMint,
                                         "이미 동일한 목표가 있어요",
-                                        "새로운 목표를 만들어 기록을 작성해보세요!").loadAndShowBottomSheet(in: self)
+                                        "새로운 목표를 만들어 기록을 작성해보세요!").show(in: self)
     }
 }

--- a/POME/Presentation/ViewControllers/Goal/GenerateGoalDateViewController.swift
+++ b/POME/Presentation/ViewControllers/Goal/GenerateGoalDateViewController.swift
@@ -108,7 +108,7 @@ final class GenerateGoalDateViewController: BaseViewController {
             }
         }()
         
-        sheet.loadAndShowBottomSheet(in: self)
+        sheet.show(in: self)
         sheet.completion = { date in
             self.viewModel.selectDate(tag: calendarType.rawValue, date)
         }

--- a/POME/Presentation/ViewControllers/Record/RecordEmotionViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/RecordEmotionViewController.swift
@@ -111,7 +111,7 @@ extension RecordEmotionViewController: UITableViewDelegate, UITableViewDataSourc
 extension RecordEmotionViewController: RecordCellDelegate{
     func presentReactionSheet(indexPath: IndexPath) {
         let data = noSecondEmotionRecord[dataIndexBy(indexPath)].friendReactions
-        FriendReactionSheetViewController(reactions: data).loadAndShowBottomSheet(in: self)
+        FriendReactionSheetViewController(reactions: data).show(in: self)
     }
     
     func presentEtcActionSheet(indexPath: IndexPath) {

--- a/POME/Presentation/ViewControllers/Record/RecordViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/RecordViewController.swift
@@ -71,7 +71,7 @@ class RecordViewController: BaseTabViewController {
     }
     @objc func writeButtonDidTap() {
         if self.goalContent.isEmpty {
-            let sheet = RecordBottomSheetViewController(Image.flagMint, "지금은 씀씀이를 기록할 수 없어요", "나만의 소비 목표를 설정하고\n기록을 시작해보세요!").loadAndShowBottomSheet(in: self)
+            let sheet = RecordBottomSheetViewController(Image.flagMint, "지금은 씀씀이를 기록할 수 없어요", "나만의 소비 목표를 설정하고\n기록을 시작해보세요!").show(in: self)
         } else {
             let goal = goalContent[categorySelectedIdx]
             let vc = GenerateRecordViewController(goal: goal)
@@ -129,13 +129,13 @@ class RecordViewController: BaseTabViewController {
     func showNoSecondEmotionWarning() {
         let sheet = RecordBottomSheetViewController(Image.penPink,
                                                     "아직 돌아보지 않은 기록이 있어요!",
-                                                    "씀씀이 기록 후 일주일 뒤에\n감정을 돌아보고 목표를 종료할 수 있어요").loadAndShowBottomSheet(in: self)
+                                                    "씀씀이 기록 후 일주일 뒤에\n감정을 돌아보고 목표를 종료할 수 있어요").show(in: self)
     }
     func cannotAddEmotionWarning() {
-        let sheet = RecordBottomSheetViewController(Image.penPink, "아직은 감정을 기록할 수 없어요", "일주일이 지나야 감정을 남길 수 있어요\n나중에 다시 봐요!").loadAndShowBottomSheet(in: self)
+        let sheet = RecordBottomSheetViewController(Image.penPink, "아직은 감정을 기록할 수 없어요", "일주일이 지나야 감정을 남길 수 있어요\n나중에 다시 봐요!").show(in: self)
     }
     func cannotAddGoalWarning() {
-        let sheet = RecordBottomSheetViewController(Image.ten, "목표는 10개를 넘을 수 없어요", "포미는 사용자가 무리하지 않고 즐겁게 목표를\n달성할 수 있도록 응원하고 있어요!").loadAndShowBottomSheet(in: self)
+        let sheet = RecordBottomSheetViewController(Image.ten, "목표는 10개를 넘을 수 없어요", "포미는 사용자가 무리하지 않고 즐겁게 목표를\n달성할 수 있도록 응원하고 있어요!").show(in: self)
     }
     
 }
@@ -289,7 +289,7 @@ extension RecordViewController: UITableViewDelegate, UITableViewDataSource {
 extension RecordViewController: RecordCellDelegate{
     func presentReactionSheet(indexPath: IndexPath) {
         let data = recordsOfGoal[dataIndexBy(indexPath)].friendReactions
-        FriendReactionSheetViewController(reactions: data).loadAndShowBottomSheet(in: self)
+        FriendReactionSheetViewController(reactions: data).show(in: self)
     }
     
     func presentEtcActionSheet(indexPath: IndexPath) {

--- a/POME/Presentation/ViewControllers/Record/Register/ModifyRecordViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/ModifyRecordViewController.swift
@@ -16,7 +16,18 @@ protocol ModifyRecord{
 final class ModifyRecordViewController: Recordable{
     
     private let record: RecordResponseModel
+    private var modifyViewModel: ModifyRecord?
+    private var tableViewIndexPath: IndexPath!
     
+    init(modifyViewModel: ModifyRecord, indexPath: IndexPath){
+        self.modifyViewModel = modifyViewModel
+        self.tableViewIndexPath = indexPath
+        self.record = modifyViewModel.getRecord(at: indexPath.row)
+        super.init(recordType: .modify, viewModel: ModifyRecordViewModel(recordId: record.id,
+                                                                         defaultGoal: modifyViewModel.selectedGoal,
+                                                                         defaultDate: record.useDate))
+    }
+    //will delete
     init(goal: GoalResponseModel, record: RecordResponseModel){
         self.record = record
         super.init(recordType: .modify,
@@ -39,10 +50,9 @@ final class ModifyRecordViewController: Recordable{
         super.bind()
         
         viewModel.controlEvent(mainView.completeButton.rx.tap)
-            .drive(onNext:{ [weak self] statusCode in
-                if(statusCode == 200){
-                    self?.navigationController?.popViewController(animated: true)
-                }
+            .subscribe(onNext: { modifyRecord in
+                self.modifyViewModel?.modifyRecord(indexPath: self.tableViewIndexPath, modifyRecord)
+                self.navigationController?.popViewController(animated: true)
             }).disposed(by: disposeBag)
     }
 }

--- a/POME/Presentation/ViewControllers/Record/Register/ModifyRecordViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/ModifyRecordViewController.swift
@@ -7,6 +7,12 @@
 
 import Foundation
 
+protocol ModifyRecord{
+    var selectedGoal: GoalResponseModel { get }
+    func getRecord(at: Int) -> RecordResponseModel
+    func modifyRecord(indexPath: IndexPath, _ record: RecordResponseModel)
+}
+
 final class ModifyRecordViewController: Recordable{
     
     private let record: RecordResponseModel

--- a/POME/Presentation/ViewControllers/Record/Register/Recordable.swift
+++ b/POME/Presentation/ViewControllers/Record/Register/Recordable.swift
@@ -114,7 +114,7 @@ class Recordable: BaseViewController{
     }
     
     private func calendarSheetWillShow(){
-        CalendarSheetViewController().loadAndShowBottomSheet(in: self).do{
+        CalendarSheetViewController().show(in: self).do{
             $0.completion = { [weak self] in
                 self?.viewModel.selectDate($0)
             }
@@ -122,7 +122,7 @@ class Recordable: BaseViewController{
     }
     
     private func categorySheetWillShow(){
-        categoryBottomSheet.loadAndShowBottomSheet(in: self)
+        categoryBottomSheet.show(in: self)
     }
 }
 

--- a/POME/Presentation/ViewControllers/Review/ReviewTestViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewTestViewController.swift
@@ -217,7 +217,7 @@ extension ReviewTestViewController: FilterDelegate{
             case .second:   return secondEmotionFilterBottomSheet
             }
         }()
-        filterSheet.loadAndShowBottomSheet(in: self)
+        filterSheet.show(in: self)
     }
     
     func initializeFilteringCondition() {
@@ -229,7 +229,7 @@ extension ReviewTestViewController: RecordCellDelegate{
     
     func presentReactionSheet(indexPath: IndexPath) {
         let data = viewModel.getRecord(at: indexPath.row).friendReactions
-        FriendReactionSheetTestViewController(reactions: data).loadAndShowBottomSheet(in: self)
+        FriendReactionSheetTestViewController(reactions: data).show(in: self)
     }
     
     func presentEtcActionSheet(indexPath: IndexPath) {

--- a/POME/Presentation/ViewControllers/Review/ReviewTestViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewTestViewController.swift
@@ -98,6 +98,11 @@ class ReviewTestViewController: BaseTabViewController{
             .drive(onNext: { indexPath in
                 self.mainView.tableView.deleteRows(at: [indexPath], with: .fade)
             }).disposed(by: disposeBag)
+        
+        output.modifyRecord
+            .drive(onNext: { indexPath in
+                self.mainView.tableView.reloadRows(at: [indexPath], with: .none)
+            }).disposed(by: disposeBag)
     }
 }
 
@@ -229,18 +234,17 @@ extension ReviewTestViewController: RecordCellDelegate{
     
     func presentEtcActionSheet(indexPath: IndexPath) {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet).then{
-            $0.addAction(generateModifyAction($0, index: indexPath.row))
+            $0.addAction(generateModifyAction($0, indexPath: indexPath))
             $0.addAction(generateDeleteAction($0, indexPath: indexPath))
             $0.addAction(generateCancelAction())
         }
         present(alert, animated: true)
     }
     
-    private func generateModifyAction(_ alert: UIAlertController, index: Int) -> UIAlertAction{
+    private func generateModifyAction(_ alert: UIAlertController, indexPath: IndexPath) -> UIAlertAction{
         return UIAlertAction(title: "수정하기", style: .default){ _ in
             alert.dismiss(animated: true)
-            let vc = ModifyRecordViewController(goal: self.viewModel.selectedGoal,
-                                                record: self.viewModel.getRecord(at: index))
+            let vc = ModifyRecordViewController(modifyViewModel: self.viewModel, indexPath: indexPath)
             self.navigationController?.pushViewController(vc, animated: true)
         }
     }
@@ -275,13 +279,10 @@ extension ReviewTestViewController{
     }
 
     private func beginPaging(){
-
         isPaging = true
-
         DispatchQueue.main.async { [self] in
             mainView.tableView.reloadSections(IndexSet(integer: 1), with: .none)
         }
-
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             self.viewModel.requestNextPage()
         }

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -128,7 +128,7 @@ class ReviewViewController: BaseTabViewController, ControlIndexPath, Pageable {
             filterView.setFilterSelectState(emotion: emotion)
         }
         
-        sheet.loadAndShowBottomSheet(in: self)
+        sheet.show(in: self)
     }
     
     @objc func filterInitializeButtonDidClicked(){
@@ -266,7 +266,7 @@ extension ReviewViewController: RecordCellDelegate{
 
     func presentReactionSheet(indexPath: IndexPath) {
         let data = records[dataIndexBy(indexPath)].friendReactions
-        FriendReactionSheetViewController(reactions: data).loadAndShowBottomSheet(in: self)
+        FriendReactionSheetViewController(reactions: data).show(in: self)
     }
     
     func presentEtcActionSheet(indexPath: IndexPath) {

--- a/POME/Presentation/ViewModel/Record/Register/ModifyRecordViewModel.swift
+++ b/POME/Presentation/ViewModel/Record/Register/ModifyRecordViewModel.swift
@@ -14,7 +14,7 @@ final class ModifyRecordViewModel: RecordableViewModel, RecordButtonControl{
     private let modifyRecordUseCase: ModifyRecordUseCaseInterface
     private let recordId: Int
     
-    typealias Output = Int
+    typealias Output = Observable<RecordResponseModel>
     
     init(recordId: Int, defaultGoal: GoalResponseModel, defaultDate: String, modifyRecordUseCase: ModifyRecordUseCaseInterface = ModifyRecordUseCase()) {
         self.recordId = recordId
@@ -22,7 +22,7 @@ final class ModifyRecordViewModel: RecordableViewModel, RecordButtonControl{
         super.init(defaultGoal: defaultGoal, defaultDate: defaultDate)
     }
     
-    func controlEvent(_ tapEvent: ControlEvent<Void>) -> Driver<Output> {
+    func controlEvent(_ tapEvent: ControlEvent<Void>) -> Output {
         return tapEvent
             .withLatestFrom(requestObservable)
             .map{ goal, date, price, comment in
@@ -32,7 +32,7 @@ final class ModifyRecordViewModel: RecordableViewModel, RecordButtonControl{
                                  usePrice: price)
             }.flatMap{
                 self.modifyRecordUseCase.execute(recordId: self.recordId, requestValue: $0)
-            }.asDriver(onErrorJustReturn: 404)
+            }.asObservable()
     }
     
 }

--- a/POME/Presentation/ViewModel/Record/Register/RecordableViewModel.swift
+++ b/POME/Presentation/ViewModel/Record/Register/RecordableViewModel.swift
@@ -17,7 +17,7 @@ protocol GoalSelectViewModel{
 
 protocol RecordButtonControl{
     associatedtype Output
-    func controlEvent(_ tapEvent: ControlEvent<Void>) -> Driver<Output>
+    func controlEvent(_ tapEvent: ControlEvent<Void>) -> Output
 }
 
 class RecordableViewModel: BaseViewModel{

--- a/POME/Presentation/ViewModel/Review/ReviewViewModel.swift
+++ b/POME/Presentation/ViewModel/Review/ReviewViewModel.swift
@@ -30,13 +30,18 @@ class ReviewViewModel: BaseViewModel{
     
     private var canRequestNextPage = false
     private var goals = [GoalResponseModel]()
-    private var records = [RecordResponseModel]()
+    private var records = [RecordResponseModel](){
+        didSet{
+            emptyViewVisibilitySubject.onNext(records.isEmpty)
+        }
+    }
     private lazy var dataIndex: (Int) -> Int = { row in row - self.regardlessOfRecordCount }
     
     private let disposeBag = DisposeBag()
     private let deleteRecordSubject = PublishSubject<IndexPath>()
     private let selectGoalRelay = BehaviorRelay<Int>(value: 0)
     private let pageRelay = BehaviorRelay<Int>(value: 0)
+    private let emptyViewVisibilitySubject = PublishSubject<Bool>()
     private let filteringConditionRelay = BehaviorRelay<FilteringCondition>(value: (nil, nil))
     
     struct Input{
@@ -130,9 +135,9 @@ class ReviewViewModel: BaseViewModel{
             .map{ _ in Void() }
             .asDriver(onErrorJustReturn: Void())
         
-        let showEmptyView = recordsResponse
-            .map{ $0.page == 0 && $0.content.isEmpty }
+        let showEmptyView = emptyViewVisibilitySubject
             .asDriver(onErrorJustReturn: false)
+        
         
         return Output(firstEmotionState: firstEmotionState,
                       secondEmotionState: secondEmotionState,


### PR DESCRIPTION
## What is this PR? 🔍
회고탭 기록 수정 / 삭제 ViewModel + RxSwift + Clean Architecture로 활용 리팩토링

## Key Changes 🔑
### 1. ActionSheet 모듈화
+ actionButton 생성을 각각의 메서드에서 수행하도록 
### 2. 회고탭 기록 수정 ViewModel + RxSwift + CleanArchitecture 기반 리팩토링 완료
+ 기록 수정 부분해서 ViewModel + Protocol 조합으로 Observabl e활용하게 설계 해놨습니다. 
+ 기록탭이나 수정 관련한 부분들 ModifyRecord 프로토콜 채택해 ViewModel 설계해주시고 적용시켜주세요~

### 3. 회고탭 기록 삭제 ViewModel + RxSwift + CleanArchitecture 기반 리팩토링 완료

### 4. BottomSheet loadAndShowBottomSheet 메서드 네이밍 변경
+ load되고 뭐 하고.. 그런거 굳이 알 필요없다 생각해 추상화하는 느낌으로 show로 네이밍 변경했습니다. 

## To Reviewers 📢
- 풀 받고 사용해주세요.


## Related Issues ⛱
#295