### PR TITLE
Feature/#295: 회고탭 테이블뷰 위>아래 스와이프시 데이터 리프레시 기능 추가

### DIFF
--- a/POME/Global/Source/Const.swift
+++ b/POME/Global/Source/Const.swift
@@ -20,6 +20,7 @@ struct Device{
 }
 
 struct Offset{
+    static let REFRESH_DATA: CGFloat = -45
     static let VIEW_CONTROLLER_TOP: CGFloat = 92
 }
 

--- a/POME/Presentation/ViewModel/Review/ReviewViewModel.swift
+++ b/POME/Presentation/ViewModel/Review/ReviewViewModel.swift
@@ -239,7 +239,7 @@ extension ReviewViewModel{
         selectGoalRelay.value
     }
     
-    func hasNextPage() -> Bool{
+    var hasNextPage: Bool{
         canRequestNextPage
     }
 }


### PR DESCRIPTION
## What is this PR? 🔍
회고탭 테이블뷰 위>아래 스와이프시 데이터 리프레시 기능 추가

## Key Changes 🔑

### 1. Offset.REFRESH_DATA 정적 프로퍼티 추가
+ 일단 임의로 -45값 지정해놨습니다. 나중에 조금 값 변동 필요하다 싶으면 조정하면 될 것 같아요
+ 기록 탭 등에서 리프레시 기능 구현할 때 Offset.REFRESH_DATA 선언해서 조건 검사 수행하시면 됩니다. 

### 2. 회고탭 테이블뷰 위>아래 스와이프시 데이터 리프레시 기능 추가
+ scollView에서 paging 검사, 리프레시 여부 검사 2가지 진행으로 인해 각각 모듈화해 기능 구현했습니다. 

이제 회고탭 리팩토링이 마무리 된 듯 싶습니다??🥹

## To Reviewers 📢
- 풀 받고 사용해주세요

## Related Issues ⛱
close #295