### PR TITLE
[feat] 기록탭 > 당겨서 새로고침 & 데이터 조회 제한

### DIFF
--- a/POME/Presentation/ViewControllers/Record/RecordViewController.swift
+++ b/POME/Presentation/ViewControllers/Record/RecordViewController.swift
@@ -24,14 +24,21 @@ class RecordViewController: BaseTabViewController {
     var recordPage: Int?
     // Cell Height
     var expendingCellContent = ExpandingTableViewCellContent()
+    // Refresh Control
+    var refreshControl = UIRefreshControl()
 
     override func viewDidLoad() {
         super.viewDidLoad()
-    }
-    override func viewWillAppear(_ animated: Bool) {
+        
+        initRefresh()
         if(!isFirstLoad){
             requestGetGoals()
         }
+    }
+    override func viewWillAppear(_ animated: Bool) {
+//        if(!isFirstLoad){
+//            requestGetGoals()
+//        }
         
     }
     override func style() {
@@ -321,6 +328,25 @@ extension RecordViewController: RecordCellDelegate{
         self.present(alert, animated: true)
     }
 }
+// MARK: - Refresh Control
+extension RecordViewController {
+    func initRefresh() {
+        refreshControl.addTarget(self, action: #selector(refreshTable(refresh:)), for: .valueChanged)
+        
+        refreshControl.backgroundColor = .white
+        refreshControl.tintColor = .black
+        
+        self.recordView.recordTableView.refreshControl = refreshControl
+    }
+    
+    @objc func refreshTable(refresh: UIRefreshControl) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            // DATA reload
+            self.requestGetGoals()
+            refresh.endRefreshing()
+        }
+    }
+}
 //MARK: - API
 extension RecordViewController {
     // MARK: 목표 리스트 조회 API
@@ -351,7 +377,7 @@ extension RecordViewController {
                     cell.goalCollectionView.reloadData()
                     self.recordView.recordTableView.reloadData()
                 }
-                
+                self.refreshControl.endRefreshing()
                 break
             default:
                 print(result)


### PR DESCRIPTION
## What is this PR? 🔍
기록탭 > 당겨서 새로고침 & 데이터 조회 제한
## Key Changes 🔑
1. 기존 appear 때마다 데이터 조회하는 방식 ->  당겨서 새로고침
2. 단, 목표/기록 생성/삭제 후 데이터 조회 메쏘드 구현X

## To Reviewers 📢
- 리뷰어들에게 할 말


## Related Issues ⛱
