### PR TITLE
Refactor/#304: 친구탭 MVVM 패턴 적용 일부 완료 및 리프레시 기능 추가

### DIFF
--- a/POME.xcodeproj/project.pbxproj
+++ b/POME.xcodeproj/project.pbxproj
@@ -2337,6 +2337,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-expression-type-checking=50 -Xfrontend -warn-long-function-bodies=50";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OBJC_BRIDGING_HEADER = "POME/Resource/POME-Bridging-Header.h";

--- a/POME.xcodeproj/project.pbxproj
+++ b/POME.xcodeproj/project.pbxproj
@@ -119,7 +119,7 @@
 		5724EC722918CFBA00DC529B /* BaseCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5724EC712918CFBA00DC529B /* BaseCollectionViewCell.swift */; };
 		5724EC762919224700DC529B /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5724EC752919224700DC529B /* PaddingLabel.swift */; };
 		5724EC78291A009F00DC529B /* ShadowStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5724EC77291A009F00DC529B /* ShadowStyle.swift */; };
-		5724EC82291B246800DC529B /* EmojiFloatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5724EC81291B246800DC529B /* EmojiFloatingView.swift */; };
+		5724EC82291B246800DC529B /* ReactionFloatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5724EC81291B246800DC529B /* ReactionFloatingView.swift */; };
 		5724EC84291B29A700DC529B /* EmojiFloatingCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5724EC83291B29A700DC529B /* EmojiFloatingCollectionViewCell.swift */; };
 		5724EC86291B4C9200DC529B /* Const.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5724EC85291B4C9200DC529B /* Const.swift */; };
 		5724EC89291B7B7B00DC529B /* Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5724EC88291B7B7B00DC529B /* Delegate.swift */; };
@@ -397,7 +397,7 @@
 		5724EC712918CFBA00DC529B /* BaseCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCollectionViewCell.swift; sourceTree = "<group>"; };
 		5724EC752919224700DC529B /* PaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingLabel.swift; sourceTree = "<group>"; };
 		5724EC77291A009F00DC529B /* ShadowStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowStyle.swift; sourceTree = "<group>"; };
-		5724EC81291B246800DC529B /* EmojiFloatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiFloatingView.swift; sourceTree = "<group>"; };
+		5724EC81291B246800DC529B /* ReactionFloatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReactionFloatingView.swift; sourceTree = "<group>"; };
 		5724EC83291B29A700DC529B /* EmojiFloatingCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiFloatingCollectionViewCell.swift; sourceTree = "<group>"; };
 		5724EC85291B4C9200DC529B /* Const.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Const.swift; sourceTree = "<group>"; };
 		5724EC88291B7B7B00DC529B /* Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Delegate.swift; sourceTree = "<group>"; };
@@ -1134,7 +1134,7 @@
 			isa = PBXGroup;
 			children = (
 				5724EC682918CECD00DC529B /* FriendView.swift */,
-				5724EC81291B246800DC529B /* EmojiFloatingView.swift */,
+				5724EC81291B246800DC529B /* ReactionFloatingView.swift */,
 				57CCA75C2925AEED007E22D1 /* FriendTableEmptyView.swift */,
 				57CCA75E2925AF2C007E22D1 /* FriendDetailView.swift */,
 				57CCA77B29289DCE007E22D1 /* FriendReactionSheetView.swift */,
@@ -2086,7 +2086,7 @@
 				2306123C292B4CB500662007 /* OnboardingViewController.swift in Sources */,
 				23858E5C292B6E6B00707572 /* TermsView.swift in Sources */,
 				57CCA795292B2D76007E22D1 /* ConsumeReviewTableViewCell.swift in Sources */,
-				5724EC82291B246800DC529B /* EmojiFloatingView.swift in Sources */,
+				5724EC82291B246800DC529B /* ReactionFloatingView.swift in Sources */,
 				23858E5A292B6E4100707572 /* TermsViewController.swift in Sources */,
 				EEE5F5E9298126E000ECD31B /* RecordResponseModel.swift in Sources */,
 				2385A8D1292C58F9003A62EA /* EmptyView.swift in Sources */,

--- a/POME/Data/Repository/FriendRepository.swift
+++ b/POME/Data/Repository/FriendRepository.swift
@@ -27,7 +27,7 @@ class FriendRepository: FriendRepositoryInterface{
     
     func registerReaction(requestValue: RegisterReactionRequestValue) -> Observable<RecordResponseModel> {
         let observable = Observable<RecordResponseModel>.create { observer -> Disposable in
-            let requestReference: () = FriendService.shared.generateFriendEmotion(id: requestValue.friendId, emotion: requestValue.emotionId) { response in
+            let requestReference: () = FriendService.shared.generateFriendEmotion(id: requestValue.recordId, emotion: requestValue.emotionId) { response in
                 switch response {
                 case .success(let data):
                     observer.onNext(data)

--- a/POME/Domain/UseCase/Friend/RegisterReactionUseCase.swift
+++ b/POME/Domain/UseCase/Friend/RegisterReactionUseCase.swift
@@ -9,7 +9,7 @@ import Foundation
 import RxSwift
 
 struct RegisterReactionRequestValue{
-    let friendId: Int
+    let recordId: Int
     let emotionId: Int
 }
 

--- a/POME/Global/Source/LinkManager/LinkManager.swift
+++ b/POME/Global/Source/LinkManager/LinkManager.swift
@@ -32,6 +32,7 @@ enum Link: String {
 class LinkManager {
     var viewcontroller: UIViewController?
     
+    @discardableResult
     init(_ vc: UIViewController, _ link: Link) {
         self.viewcontroller = vc
         

--- a/POME/Global/Source/Protocol/Delegate.swift
+++ b/POME/Global/Source/Protocol/Delegate.swift
@@ -12,10 +12,8 @@ protocol RecordCellDelegate{
     func presentEtcActionSheet(indexPath: IndexPath)
 }
 
-protocol FriendRecordCellDelegate{
-    func presentReactionSheet(indexPath: IndexPath)
-    func presentEtcActionSheet(indexPath: IndexPath)
-    func presentEmojiFloatingView(indexPath: IndexPath)
+protocol FriendRecordCellDelegate: RecordCellDelegate{
+    func willShowReactionFloatingView(indexPath: IndexPath)
     func requestGenerateFriendCardEmotion(reactionIndex: Int)
 }
 

--- a/POME/Global/Source/Protocol/Delegate.swift
+++ b/POME/Global/Source/Protocol/Delegate.swift
@@ -14,6 +14,5 @@ protocol RecordCellDelegate{
 
 protocol FriendRecordCellDelegate: RecordCellDelegate{
     func willShowReactionFloatingView(indexPath: IndexPath)
-    func requestGenerateFriendCardEmotion(reactionIndex: Int)
 }
 

--- a/POME/Global/Source/TabBar/TabBarController.swift
+++ b/POME/Global/Source/TabBar/TabBarController.swift
@@ -56,7 +56,7 @@ class TabBarController: UITabBarController {
         
         let tabs = [UINavigationController(rootViewController: recordViewController),
                     UINavigationController(rootViewController: ReviewTestViewController(btnImage: UIImage())),
-                    UINavigationController(rootViewController: FriendViewController(btnImage: Image.addPeople)),
+                    UINavigationController(rootViewController: FriendTestViewController()),
                     UINavigationController(rootViewController: MyPageViewController(btnImage: Image.setting))]
         
         TabBarItem.allCases.forEach {

--- a/POME/Presentation/Cells/Friend/FriendCollectionViewCell.swift
+++ b/POME/Presentation/Cells/Friend/FriendCollectionViewCell.swift
@@ -26,25 +26,13 @@ class FriendCollectionViewCell: BaseCollectionViewCell {
         $0.numberOfLines = 1
         $0.textAlignment = .center
     }
-    
-    //MARK: - LifeCycle
-    
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
+
     //MARK: - Override
     
     override func hierarchy() {
-        
         super.hierarchy()
-        
-        self.baseView.addSubview(profileImage)
-        self.baseView.addSubview(nameLabel)
+        baseView.addSubview(profileImage)
+        baseView.addSubview(nameLabel)
     }
     
     override func layout() {
@@ -68,26 +56,21 @@ class FriendCollectionViewCell: BaseCollectionViewCell {
     override func prepareForReuse() {
         nameLabel.text = ""
         nameLabel.textColor = Color.grey5
-    
         profileImage.image = Image.photoDefault
     }
     
     //MARK: - Method
 
     func setSelectState(row: Int){
-        
-        self.nameLabel.textColor = Color.title
-        
-        if(row == 0){
+        nameLabel.textColor = Color.title
+        if row == 0 {
             profileImage.image = Image.categoryActive
         }
     }
     
     func setUnselectState(row: Int){
-        
-        self.nameLabel.textColor = Color.grey5
-        
-        if(row == 0){
+        nameLabel.textColor = Color.grey5
+        if row == 0 {
             profileImage.image = Image.categoryInactive
         }
     }

--- a/POME/Presentation/Cells/Friend/FriendTableViewCell.swift
+++ b/POME/Presentation/Cells/Friend/FriendTableViewCell.swift
@@ -41,7 +41,7 @@ class FriendTableViewCell: BaseTableViewCell {
     
     @objc func myReactionBtnDidClicked(){
         if let index = getCellIndex(){
-            delegate?.presentEmojiFloatingView(indexPath: index)
+            delegate?.willShowReactionFloatingView(indexPath: index)
         }
     }
     

--- a/POME/Presentation/ViewControllers/Friend/FriendTestViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendTestViewController.swift
@@ -41,7 +41,7 @@ final class FriendTestViewController: BaseTabViewController{
     private let COUNT_OF_NOT_RECORD_CELL = 1
     
     private let mainView = FriendView()
-    private let reactionFloatingView = EmojiFloatingView()
+    private let reactionFloatingView = ReactionFloatingView()
     
     private let willRefreshData = BehaviorSubject<Void>(value: ())
     private let willPaging = PublishSubject<Void>()

--- a/POME/Presentation/ViewControllers/Friend/FriendTestViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendTestViewController.swift
@@ -6,7 +6,305 @@
 //
 
 import Foundation
+import RxSwift
+import RxCocoa
 
-class FriendTestViewController: BaseTabViewController{
+private extension IndexPath{
+    var ofFriendData: Int{
+        row - 1
+    }
+    var ofRecordData: Int{
+        row - 1
+    }
+}
+
+final class FriendTestViewController: BaseTabViewController{
     
+    private let viewModel: any FriendViewModelInterface
+    
+    init(viewModel: any FriendViewModelInterface = FriendViewModel()){
+        self.viewModel = viewModel
+        super.init(btnImage: Image.addPeople)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private var isLoading = false
+    
+    private let FRIEND_LIST_TABLEVIEW_CELL: IndexPath = [1,0]
+    private let COUNT_OF_NOT_RECORD_CELL = 1
+    
+    private let mainView = FriendView()
+    private let reactionFloatingView = EmojiFloatingView()
+    
+    private let willRefreshData = BehaviorSubject<Void>(value: ())
+    private let willPaging = PublishSubject<Void>()
+    private let selectedFriendCellIndex = BehaviorRelay(value: 0)
+    private let selectedRecordCellIndex = PublishSubject<Int>()
+    private let selectedReactionId = PublishSubject<Int>()
+    
+    override func layout() {
+        
+        super.layout()
+        
+        let tabBarHeight = tabBarController?.tabBar.frame.height
+        
+        view.addSubview(mainView)
+        mainView.snp.makeConstraints{
+            $0.top.equalToSuperview().offset(Offset.VIEW_CONTROLLER_TOP)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalToSuperview().offset(-tabBarHeight!)
+        }
+    }
+    
+    override func initialize() {
+        setTableViewDelegate()
+    }
+    
+    private func setTableViewDelegate(){
+        mainView.tableView.delegate = self
+        mainView.tableView.dataSource = self
+        mainView.tableView.separatorStyle = .none
+    }
+    
+    override func bind() {
+        
+        guard let viewModel = viewModel as? FriendViewModel else { return }
+        
+        let input = FriendViewModel.Input(
+            refreshView: willRefreshData.asObservable(),
+            willPaging: willPaging.asObservable(),
+            friendCellIndex: selectedFriendCellIndex.asObservable(),
+            recordIndex: selectedRecordCellIndex.asObservable(),
+            reactionId: selectedReactionId.asObservable()
+        )
+        
+        let output = viewModel.transform(input)
+        
+        output.reloadFriends
+            .subscribe(onNext: { [self] in
+                mainView.tableView
+                    .cellForRow(at: FRIEND_LIST_TABLEVIEW_CELL, cellType: FriendListTableViewCell.self)?
+                    .collectionView.reloadData()
+            }).disposed(by: disposeBag)
+        
+        output.reloadRecords
+            .subscribe(onNext: { [weak self] in
+                self?.isLoading = false
+                self?.isTableViewEmpty()
+                self?.mainView.tableView.reloadData()
+            }).disposed(by: disposeBag)
+    }
+    
+    private func isTableViewEmpty(){
+        if viewModel.friends.isEmpty {
+            mainView.emptyViewWillShow(case: .nofriend)
+        } else if viewModel.records.isEmpty {
+            mainView.emptyViewWillShow(case: .noRecord)
+        } else {
+            mainView.emptyViewWillHide()
+        }
+    }
+    
+    override func topBtnDidClicked() {
+        let vc = FriendSearchViewController().then{
+            $0.isFromRegister = false
+        }
+        navigationController?.pushViewController(vc, animated: true)
+    }
+}
+
+extension FriendTestViewController: UICollectionViewDelegate, UICollectionViewDataSource{
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        viewModel.friends.count + COUNT_OF_NOT_RECORD_CELL
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(for: indexPath, cellType: FriendCollectionViewCell.self)
+        switch indexPath.row {
+        case 0:     return getAllFriends(cell)
+        default:    return getFriend(cell, indexPath: indexPath)
+        }
+    }
+    
+    private func getAllFriends(_ cell: FriendCollectionViewCell) -> FriendCollectionViewCell{
+        cell.do{
+            $0.profileImage.image = Image.categoryInactive
+            $0.nameLabel.text = "전체"
+        }
+        return checkFriendCellSelectState(cell, index: 0)
+    }
+
+    private func getFriend(_ cell: FriendCollectionViewCell, indexPath: IndexPath) -> FriendCollectionViewCell{
+        let friend = viewModel.friends[indexPath.ofFriendData]
+        cell.do{
+            $0.nameLabel.text = friend.friendNickName
+            $0.profileImage.kf.setImage(with: URL(string: friend.imageKey), placeholder: Image.photoDefault)
+        }
+        return checkFriendCellSelectState(cell, index: indexPath.row)
+    }
+
+    private func checkFriendCellSelectState(_ cell: FriendCollectionViewCell, index: Int) -> FriendCollectionViewCell{
+        if index == selectedFriendCellIndex.value {
+            cell.setSelectState(row: index)
+        }
+        return cell
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        
+        collectionView.cellForItem(at: [0, selectedFriendCellIndex.value], cellType: FriendCollectionViewCell.self)?.do{
+            $0.setUnselectState(row: selectedFriendCellIndex.value)
+        }
+        
+        collectionView.cellForItem(at: indexPath, cellType: FriendCollectionViewCell.self)?.do{
+            $0.setSelectState(row: indexPath.row)
+        }
+        selectedFriendCellIndex.accept(indexPath.row)
+    }
+}
+
+extension FriendTestViewController: UITableViewDelegate, UITableViewDataSource{
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        3
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if section == 1 {
+            return viewModel.records.count + COUNT_OF_NOT_RECORD_CELL
+        }else if (section == 0 && isLoading) || (section == 2 && isLoading && viewModel.hasNextPage){
+            return 1
+        }else{
+            return 0
+        }
+    }
+    
+    private typealias FriendListTableViewCell = FriendView.FriendListTableViewCell
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        switch indexPath.section {
+        case 1:     return getFriendTableViewCell(indexPath: indexPath)
+        default:    return getLoadingCell(indexPath: indexPath)
+        }
+    }
+    private func getFriendTableViewCell(indexPath: IndexPath) -> BaseTableViewCell {
+        switch indexPath.row {
+        case 0:     return getFriendsListCell(indexPath: indexPath)
+        default:    return getFriendRecordCell(indexPath: indexPath)
+        }
+    }
+    private func getFriendsListCell(indexPath: IndexPath) -> BaseTableViewCell{
+        mainView.tableView.dequeueReusableCell(for: indexPath, cellType: FriendListTableViewCell.self).then{
+            $0.collectionView.delegate = self
+            $0.collectionView.dataSource = self
+        }
+    }
+    
+    private func getFriendRecordCell(indexPath: IndexPath) -> BaseTableViewCell{
+        mainView.tableView.dequeueReusableCell(for: indexPath, cellType: FriendTableViewCell.self).then{
+            $0.delegate = self
+            $0.bindingData(viewModel.records[indexPath.ofRecordData])
+        }
+    }
+    
+    private func getLoadingCell(indexPath: IndexPath) -> BaseTableViewCell{
+        mainView.tableView.dequeueReusableCell(for: indexPath, cellType: LoadingTableViewCell.self).then{
+            $0.startLoading()
+        }
+    }
+}
+
+extension FriendTestViewController: FriendRecordCellDelegate{
+    
+    func presentReactionSheet(indexPath: IndexPath) {
+        let reactions = viewModel.records[indexPath.ofRecordData].friendReactions
+        FriendReactionSheetTestViewController(reactions: reactions).show(in: self)
+    }
+    
+    func presentEtcActionSheet(indexPath: IndexPath) {
+        
+    }
+    
+    func willShowReactionFloatingView(indexPath: IndexPath) {
+        if isSufficientToShowFloatingView(indexPath: indexPath) {
+            showReactionFloatingView(indexPath: indexPath)
+        } else {
+            ToastMessageView.generateMakeSufficientSpaceMessage().show(in: self)
+        }
+    }
+    
+    private func isSufficientToShowFloatingView(indexPath: IndexPath) -> Bool {
+        
+        let rectOfCellInTableView = mainView.tableView.rectForRow(at: indexPath)
+        let rectOfCellInSuperview = mainView.tableView.convert(rectOfCellInTableView, to: view)
+
+        let viewPosition = CGPoint(x: rectOfCellInSuperview.origin.x,
+                                   y: rectOfCellInSuperview.origin.y + rectOfCellInSuperview.height)
+        
+        return Device.HEIGHT - viewPosition.y - view.safeAreaInsets.bottom >= 74
+    }
+    
+    private func showReactionFloatingView(indexPath: IndexPath){
+        
+        guard let cell = mainView.tableView.cellForRow(at: indexPath) as? FriendTableViewCell else { return }
+        
+        reactionFloatingView.delegate = self
+        reactionFloatingView.show(in: self, standard: cell)
+        
+        selectedRecordCellIndex.onNext(indexPath.ofRecordData)
+    }
+    
+    func requestGenerateFriendCardEmotion(reactionIndex: Int) {
+        
+    }
+}
+
+extension FriendTestViewController{
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let offsetY = scrollView.contentOffset.y
+        checkPaigingConditionAndStartPaging(offset: offsetY, scrollView: scrollView)
+        checkRefreshingConditionAndStartRefreshing(offset: offsetY)
+    }
+    
+    private func checkPaigingConditionAndStartPaging(offset: CGFloat, scrollView: UIScrollView){
+        let contentHeight = scrollView.contentSize.height
+        let height = scrollView.frame.height
+        
+        if offset > (contentHeight - height) {
+            if !isLoading && viewModel.hasNextPage {
+                beginPaging()
+            }
+        }
+    }
+    
+    private func beginPaging(){
+        isLoading = true
+        DispatchQueue.main.async { [self] in
+            mainView.tableView.reloadSections(IndexSet(integer: 1), with: .none)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            self.willPaging.onNext(())
+        }
+    }
+    
+    private func checkRefreshingConditionAndStartRefreshing(offset: CGFloat){
+        if offset < Offset.REFRESH_DATA && !isLoading {
+            beginRefreshData()
+        }
+    }
+    
+    private func beginRefreshData(){
+        isLoading = true
+        DispatchQueue.main.async { [self] in
+            mainView.tableView.reloadSections(IndexSet(integer: 0), with: .none)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            self.willRefreshData.onNext(())
+        }
+    }
 }

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -251,24 +251,24 @@ extension FriendViewController{
     }
     
     
-    func requestGenerateFriendCardEmotion(reactionIndex: Int){
+    func requestGenerateFriendCardEmotion(reactionId: Int){
         
         guard let cellIndex = self.currentEmotionSelectCardIndex,
-                let reaction = Reaction(rawValue: reactionIndex) else { return }
+                let reaction = Reaction(rawValue: reactionId) else { return }
         
         FriendService.shared.generateFriendEmotion(id: records[cellIndex].id,
-                                                   emotion: reactionIndex){ result in
+                                                   emotion: reactionId){ result in
             switch result{
             case .success(let data):
                 print("LOG: success requestGenerateFriendCardEmotion", data)
                 self.records[cellIndex] = data
-                self.emoijiFloatingView?.dismiss()
+//                self.emoijiFloatingView?.dismiss()
                 ToastMessageView.generateReactionMessage(type: reaction).show(in: self)
                 break
             default:
                 print("LOG: fail requestGenerateFriendCardEmotion", result)
                 NetworkAlert.show(in: self){ [weak self] in
-                    self?.requestGenerateFriendCardEmotion(reactionIndex: reactionIndex)
+                    self?.requestGenerateFriendCardEmotion(reactionId: reactionId)
                 }
                 break
             }
@@ -399,21 +399,21 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Frie
     
     func willShowReactionFloatingView(indexPath: IndexPath) {
 
-        isSufficientToShowFloatingView(indexPath: indexPath){
-            
-            currentEmotionSelectCardIndex = dataIndexBy(indexPath)
-            emoijiFloatingView = EmojiFloatingView().then{
-                $0.delegate = self
-                $0.completion = {
-                    print("LOG: emoijiFloatingView completion closure called")
-                    self.currentEmotionSelectCardIndex = nil
-                    self.emoijiFloatingView = nil
-                }
-            }
-
-            guard let cell = friendView.tableView.cellForRow(at: indexPath) as? FriendTableViewCell else { return }
-            emoijiFloatingView.show(in: self, standard: cell)
-        }
+//        isSufficientToShowFloatingView(indexPath: indexPath){
+//
+//            currentEmotionSelectCardIndex = dataIndexBy(indexPath)
+//            emoijiFloatingView = EmojiFloatingView().then{
+//                $0.delegate = self
+//                $0.completion = {
+//                    print("LOG: emoijiFloatingView completion closure called")
+//                    self.currentEmotionSelectCardIndex = nil
+//                    self.emoijiFloatingView = nil
+//                }
+//            }
+//
+//            guard let cell = friendView.tableView.cellForRow(at: indexPath) as? FriendTableViewCell else { return }
+//            emoijiFloatingView.show(in: self, standard: cell)
+//        }
     }
     
     private func isSufficientToShowFloatingView(indexPath: IndexPath, closure: () -> Void){

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -60,7 +60,7 @@ class FriendViewController: BaseTabViewController, ControlIndexPath, Pageable {
     private typealias FriendListTableViewCell = FriendView.FriendListTableViewCell
     
     let friendView = FriendView()
-    var emoijiFloatingView: EmojiFloatingView!
+    var emoijiFloatingView: ReactionFloatingView!
     
     //MARK: - Override
     

--- a/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
+++ b/POME/Presentation/ViewControllers/Friend/FriendViewController.swift
@@ -397,7 +397,7 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Frie
         return cell
     }
     
-    func presentEmojiFloatingView(indexPath: IndexPath) {
+    func willShowReactionFloatingView(indexPath: IndexPath) {
 
         isSufficientToShowFloatingView(indexPath: indexPath){
             
@@ -459,6 +459,6 @@ extension FriendViewController: UITableViewDelegate, UITableViewDataSource, Frie
         alert.addAction(declarationAction)
         alert.addAction(cancelAction)
              
-        self.present(alert, animated: true)
+        present(alert, animated: true)
     }
 }

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -59,7 +59,7 @@ class ReviewViewController: BaseTabViewController, ControlIndexPath, Pageable {
     }
     
     let mainView = ReviewView()
-    var emoijiFloatingView: EmojiFloatingView!
+    var emoijiFloatingView: ReactionFloatingView!
     
     override func viewWillAppear(_ animated: Bool) {
         page = 0

--- a/POME/Presentation/ViewModel/Friend/FriendViewModel.swift
+++ b/POME/Presentation/ViewModel/Friend/FriendViewModel.swift
@@ -9,39 +9,117 @@ import Foundation
 import RxSwift
 import RxCocoa
 
-protocol FriendViewModelInterface{
-    
+protocol FriendViewModelInterface: BaseViewModel{
+    var friends: [FriendsResponseModel] { get }
+    var records: [RecordResponseModel] { get }
+    var hasNextPage: Bool { get }
 }
 
 class FriendViewModel: FriendViewModelInterface{
+
+    var friends = [FriendsResponseModel]()
+    var records = [RecordResponseModel]()
+    var hasNextPage = false
     
-//    private let friendUseCase: GetFriendReviewUseCase
+    
+    private let getFriendsUseCase: GetFriendsUseCaseInterface
+    private let getAllFriendsRecordsUseCase: GetAllFriendsRecordsUseCaseInterface
+    private let getFriendRecordsUseCase: GetFriendRecordsUseCaseInterface
+    private let hideFriendRecordUseCase: HideRecordUseCaseInterface
+    private let registerRecordReactionUseCase: RegisterReactionUseCaseInterface
+    
+    init(getFriendsUseCase: GetFriendsUseCaseInterface = GetFriendsUseCase(),
+         getAllFriendsRecordsUseCase: GetAllFriendsRecordsUseCaseInterface = GetAllFriendsRecordsUseCase(),
+         getFriendRecordsUseCase: GetFriendRecordsUseCaseInterface = GetFriendRecordsUseCase(),
+         hideFriendRecordUseCase: HideRecordUseCaseInterface = HideRecordUseCase(),
+         registerRecordReactionUseCase: RegisterReactionUseCaseInterface = RegisterReactionUseCase()) {
+        self.getFriendsUseCase = getFriendsUseCase
+        self.getAllFriendsRecordsUseCase = getAllFriendsRecordsUseCase
+        self.getFriendRecordsUseCase = getFriendRecordsUseCase
+        self.hideFriendRecordUseCase = hideFriendRecordUseCase
+        self.registerRecordReactionUseCase = registerRecordReactionUseCase
+    }
+    
+    private var friendIndex = 0
+    
+    private let pageRelay = PublishRelay<Int>()
+    private let disposeBag = DisposeBag()
     
     struct Input{
-        let viewWillAppear: Observable<Void>
-        let friendId: Observable<Int>
-        let leaveEmotionToFriend: ControlEvent<Void>
+        let refreshView: Observable<Void>
+        let willPaging: Observable<Void>
+        let friendCellIndex: Observable<Int>
+        let recordIndex: Observable<Int>
+        let reactionId: Observable<Int>
     }
     
     struct Output{
-        let friends: Driver<[String]>
-        let friendCards: Driver<[Reaction?]>
+        let reloadFriends: Observable<Void>
+        let reloadRecords: Observable<Void>
     }
     
-//    func transform(input: Input) -> Output{
-//        return Output(friends: <#Driver<[String]>#>,
-//                      friendCards: <#Driver<[Reaction?]>#>)
-//    }
+    func transform(_ input: Input) -> Output {
+        
+        let friendsResponse = input.refreshView
+            .flatMap{
+                self.getFriendsUseCase.execute()
+            }.share()
+        
+        let reloadCollectionView = friendsResponse
+            .do{
+                self.friends = $0
+                self.pageRelay.accept(0)
+            }.map{ _ in
+                ()
+            }
+                
+        input.willPaging
+            .subscribe(onNext: {
+                self.pageRelay.accept(1)
+            }).disposed(by: disposeBag)
+        
+        input.friendCellIndex
+            .subscribe(onNext: {
+                self.friendIndex = $0
+                self.pageRelay.accept(0)
+            })
+            .disposed(by: disposeBag)
+                
+                
+        let requestPage = pageRelay
+                .scan((0,0)){
+                    $1 == 0 ? ($0.1, 0) : ($0.1, $0.1 + $1) //0인 경우 0 반환, 1인 경우 page + 1 반환
+                }.map{
+                    $0.1
+                }
+                .share()
+        
+        let recordsResponse = requestPage
+            .flatMap{ [self] page in
+                let pageModel = PageableModel(page: page)
+                return friendIndex == 0
+                ? self.getAllFriendsRecordsUseCase.execute(requestModel: pageModel)
+                : self.getFriendRecordsUseCase.execute(
+                    requestModel: GetFriendRecordsRequestValue(
+                        friendId: self.friends[friendIndex - 1].friendUserId,
+                        pageable: pageModel
+                    )
+                )
+            }.share()
+        
+        let reloadTableView: Observable<Void> = recordsResponse
+            .do(onNext: { [weak self] in
+                self?.hasNextPage = !$0.last
+                self?.records = $0.content
+            })
+            .map{ _ in () }
+            
+        
+        return Output(
+            reloadFriends: reloadCollectionView,
+            reloadRecords: reloadTableView
+        )
+    }
     
     
 }
-
-
- /* api
-  1. 친구 리스트 조회
-  2. 모든 친구 기록
-  3. 특정 친구 기록
-  4. 친구 기록에 리액션 남기기
-  5. 친구 기록 숨기기
-  */
-

--- a/POME/Presentation/ViewModel/Friend/FriendViewModel.swift
+++ b/POME/Presentation/ViewModel/Friend/FriendViewModel.swift
@@ -13,6 +13,10 @@ protocol FriendViewModelInterface: BaseViewModel{
     var friends: [FriendsResponseModel] { get }
     var records: [RecordResponseModel] { get }
     var hasNextPage: Bool { get }
+    var registerReactionCompleted: ((Int) -> Void)! { get }
+    func registerReaction(id: Int, index: Int)
+//    var hideRecordCompleted: () { get }
+//    func hideRecord(index: Int)
 }
 
 class FriendViewModel: FriendViewModelInterface{
@@ -20,6 +24,8 @@ class FriendViewModel: FriendViewModelInterface{
     var friends = [FriendsResponseModel]()
     var records = [RecordResponseModel]()
     var hasNextPage = false
+    
+    var registerReactionCompleted: ((Int) -> Void)!
     
     
     private let getFriendsUseCase: GetFriendsUseCaseInterface
@@ -49,8 +55,6 @@ class FriendViewModel: FriendViewModelInterface{
         let refreshView: Observable<Void>
         let willPaging: Observable<Void>
         let friendCellIndex: Observable<Int>
-        let recordIndex: Observable<Int>
-        let reactionId: Observable<Int>
     }
     
     struct Output{
@@ -121,5 +125,12 @@ class FriendViewModel: FriendViewModelInterface{
         )
     }
     
-    
+    func registerReaction(id reactionId: Int, index: Int) {
+        registerRecordReactionUseCase.execute(
+            requestValue: RegisterReactionRequestValue(recordId: records[index].id, emotionId: reactionId)
+        ).subscribe{ [weak self] in
+            self?.records[index] = $0
+            self?.registerReactionCompleted(index)
+        }.disposed(by: disposeBag)
+    }
 }

--- a/POME/Presentation/Views/Friend/EmojiFloatingView.swift
+++ b/POME/Presentation/Views/Friend/EmojiFloatingView.swift
@@ -12,14 +12,14 @@ final class EmojiFloatingView: BaseView {
     var delegate: FriendRecordCellDelegate!
     var completion: (() -> ())!
     
-    let containerView = UIView().then{
+    private let containerView = UIView().then{
         $0.backgroundColor = .white
         $0.setShadowStyle(type: .card)
         $0.clipsToBounds = false
         $0.layer.cornerRadius = 54/2
     }
     
-    let collectionView = UICollectionView(frame: .zero, collectionViewLayout: .init()).then{
+    private let collectionView = UICollectionView(frame: .zero, collectionViewLayout: .init()).then{
         
         let flowLayout = UICollectionViewFlowLayout().then{
             $0.minimumLineSpacing = 14
@@ -42,13 +42,13 @@ final class EmojiFloatingView: BaseView {
         let dismissGesture = UITapGestureRecognizer(target: self, action: #selector(dismiss)).then{
             $0.delegate = self
         }
-        self.addGestureRecognizer(dismissGesture)
+        addGestureRecognizer(dismissGesture)
         
         collectionView.dataSource = self
         collectionView.delegate = self
     }
     
-    @objc func dismiss(){
+    @objc private func dismiss(){
         DispatchQueue.main.async {
             UIView.animate(withDuration: 0.3, animations: {
                 self.transform = CGAffineTransform(translationX: 0, y: 10)
@@ -61,7 +61,7 @@ final class EmojiFloatingView: BaseView {
     }
     
     override func hierarchy() {
-        self.addSubview(containerView)
+        addSubview(containerView)
         containerView.addSubview(collectionView)
     }
     

--- a/POME/Presentation/Views/Friend/ReactionFloatingView.swift
+++ b/POME/Presentation/Views/Friend/ReactionFloatingView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class EmojiFloatingView: BaseView {
+final class ReactionFloatingView: BaseView {
     
     var delegate: FriendRecordCellDelegate!
     var completion: (() -> ())!


### PR DESCRIPTION
## What is this PR? 🔍

## Key Changes 🔑

### 빌드 관련 
1. 빌드 속도 개선 위한 빌드 시간 50ms 이상 컴파일 경고 띄우기

### 친구탭 리팩토링
1. 친구 조회
2. 기록 조회
3. 친구 기록 리액션 남기기

위 3가지에 대해서 MVVM 적용 완료했습니다. 

리프레시 관련해 회고탭과 친구탭에 페이징 조회에 사용하던 LoadingTableViewCell을 활용했었는데, 
민채 언니 코드 확인해보니 UIRefreshControl을 활용하는 것이 더 맞다고 판단이 되어 일단 친구탭 먼저 수정 진행했습니다!
회고탭도 이후 수정 진행하도록 하겠습니다.

## To Reviewers 📢
- 프로젝트 파일 변경된 부분이 있으므로 풀 받고 사용해주세요


## Related Issues ⛱
#304