### PR TITLE
[REFACTOR] #308 : 회고탭 감정 필터링 리팩토링

### DIFF
--- a/POME.xcodeproj/project.pbxproj
+++ b/POME.xcodeproj/project.pbxproj
@@ -244,7 +244,7 @@
 		EEC5CAF929B0AD0F00FF4C26 /* RenewRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC5CAF829B0AD0F00FF4C26 /* RenewRequestModel.swift */; };
 		EEC5CAFB29B0B4D800FF4C26 /* MoyaLoggerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC5CAFA29B0B4D800FF4C26 /* MoyaLoggerPlugin.swift */; };
 		EEC5EC002986AB34001D6460 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC5EBFF2986AB34001D6460 /* NetworkResult.swift */; };
-		EED4AE6329DD72D2002C8965 /* EmotionFilterSheetTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EED4AE6229DD72D2002C8965 /* EmotionFilterSheetTestViewController.swift */; };
+		EED4AE6329DD72D2002C8965 /* EmotionFilterSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EED4AE6229DD72D2002C8965 /* EmotionFilterSheetViewController.swift */; };
 		EEE5F5E7298126D500ECD31B /* RecordRegisterRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE5F5E6298126D500ECD31B /* RecordRegisterRequestModel.swift */; };
 		EEE5F5E9298126E000ECD31B /* RecordResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE5F5E8298126E000ECD31B /* RecordResponseModel.swift */; };
 		EEE5F5EB2981270700ECD31B /* FriendEmotionRequestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE5F5EA2981270700ECD31B /* FriendEmotionRequestModel.swift */; };
@@ -522,7 +522,7 @@
 		EEC5CAF829B0AD0F00FF4C26 /* RenewRequestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenewRequestModel.swift; sourceTree = "<group>"; };
 		EEC5CAFA29B0B4D800FF4C26 /* MoyaLoggerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoyaLoggerPlugin.swift; sourceTree = "<group>"; };
 		EEC5EBFF2986AB34001D6460 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
-		EED4AE6229DD72D2002C8965 /* EmotionFilterSheetTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmotionFilterSheetTestViewController.swift; sourceTree = "<group>"; };
+		EED4AE6229DD72D2002C8965 /* EmotionFilterSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmotionFilterSheetViewController.swift; sourceTree = "<group>"; };
 		EEE5F5E6298126D500ECD31B /* RecordRegisterRequestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordRegisterRequestModel.swift; sourceTree = "<group>"; };
 		EEE5F5E8298126E000ECD31B /* RecordResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordResponseModel.swift; sourceTree = "<group>"; };
 		EEE5F5EA2981270700ECD31B /* FriendEmotionRequestModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendEmotionRequestModel.swift; sourceTree = "<group>"; };
@@ -1068,7 +1068,7 @@
 		5724EC55291772EA00DC529B /* Review */ = {
 			isa = PBXGroup;
 			children = (
-				EED4AE6229DD72D2002C8965 /* EmotionFilterSheetTestViewController.swift */,
+				EED4AE6229DD72D2002C8965 /* EmotionFilterSheetViewController.swift */,
 				EE39696229DAA143003F655F /* ReviewViewController.swift */,
 			);
 			path = Review;
@@ -2003,7 +2003,7 @@
 				2338F4AC2989079400F37EA1 /* TapGesture.swift in Sources */,
 				57CCA78D292B0AB4007E22D1 /* GoalTagCollectionViewCell.swift in Sources */,
 				EEC28CCE29D30DFE0075CD4C /* GenerateGoalUseCase.swift in Sources */,
-				EED4AE6329DD72D2002C8965 /* EmotionFilterSheetTestViewController.swift in Sources */,
+				EED4AE6329DD72D2002C8965 /* EmotionFilterSheetViewController.swift in Sources */,
 				57CCA77F29290212007E22D1 /* FriendReactionCollectionViewCell.swift in Sources */,
 				EE98F0C92980E126007BFCCD /* UserDefault.swift in Sources */,
 				EE79C29F29937CA1006A9AA2 /* FriendProfileImageManager.swift in Sources */,

--- a/POME/Presentation/Cells/Review/ScrollView/ReviewFilterTableViewCell.swift
+++ b/POME/Presentation/Cells/Review/ScrollView/ReviewFilterTableViewCell.swift
@@ -31,10 +31,10 @@ class ReviewFilterTableViewCell: BaseTableViewCell{
         $0.axis = .horizontal
     }
     
-    let firstEmotionFilter = EmotionFilterView.generateFirstEmotionFilter()
-    let secondEmotionFilter = EmotionFilterView.generateSecondEmotionFilter()
+    private let firstEmotionFilter = EmotionFilterView.generateFirstEmotionFilter()
+    private let secondEmotionFilter = EmotionFilterView.generateSecondEmotionFilter()
     
-    lazy var reloadingButton = UIButton()
+    private lazy var reloadingButton = UIButton()
     
     private let reloadingLabel = UILabel().then{
         $0.text = "초기화"
@@ -121,6 +121,11 @@ class ReviewFilterTableViewCell: BaseTableViewCell{
     @objc private func initializeButtonDidTapped(){
         delegate?.initializeFilteringCondition()
     }
+    
+    func changeEmotionSelectState(firstEmotionId: Int?, secondEmotionId: Int?){
+        firstEmotionFilter.setEmotionFilterState(emotionId: firstEmotionId)
+        secondEmotionFilter.setEmotionFilterState(emotionId: secondEmotionId)
+    }
 }
 
 extension EmotionTime{
@@ -135,6 +140,14 @@ extension EmotionTime{
 extension ReviewFilterTableViewCell{
     
     class EmotionFilterView: BaseView{
+        
+        static func generateFirstEmotionFilter() -> EmotionFilterView{
+            EmotionFilterView(time: .first)
+        }
+        
+        static func generateSecondEmotionFilter() -> EmotionFilterView{
+            EmotionFilterView(time: .second)
+        }
         
         private let time: EmotionTime
         
@@ -162,27 +175,26 @@ extension ReviewFilterTableViewCell{
             $0.isUserInteractionEnabled = false
         }
         
-        static func generateFirstEmotionFilter() -> EmotionFilterView{
-            EmotionFilterView(time: .first)
-        }
-        
-        static func generateSecondEmotionFilter() -> EmotionFilterView{
-            EmotionFilterView(time: .second)
-        }
-        
         //MARK: - Method
-        func setFilterDefaultState(){
+        private func setFilterDefaultState(){
             titleLabel.text = time.title
             titleLabel.textColor = Color.grey5
             filterButton.backgroundColor = Color.grey1
             arrowImage.tintColor = Color.grey5
         }
         
-        func setFilterSelectState(emotion: EmotionTag){
+        private func setFilterSelectState(emotion: EmotionTag){
             titleLabel.text = emotion.message
             titleLabel.textColor = Color.pink100
             filterButton.backgroundColor = Color.pink10
             arrowImage.tintColor = Color.pink100
+        }
+        
+        func setEmotionFilterState(emotionId: Int?){
+            guard let emotionId = emotionId, let emotion = EmotionTag(rawValue: emotionId) else {
+                setFilterDefaultState(); return
+            }
+            setFilterSelectState(emotion: emotion)
         }
         
         //MARK: - Override

--- a/POME/Presentation/ViewControllers/Review/EmotionFilterSheetTestViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/EmotionFilterSheetTestViewController.swift
@@ -9,12 +9,20 @@ import Foundation
 
 class EmotionFilterSheetViewController: BaseSheetViewController {
     
-    private let emotionTime: EmotionTime
-    private let reviewViewModel: ReviewViewModel
+    static func generateFirstEmotionFilter() -> EmotionFilterSheetViewController{
+        EmotionFilterSheetViewController(emotionTime: .first)
+    }
     
-    private init(emotionTime: EmotionTime, viewModel: ReviewViewModel){
+    static func generateSecondEmotionFilter() -> EmotionFilterSheetViewController{
+        EmotionFilterSheetViewController(emotionTime: .second)
+    }
+    
+    var selectedEmotion: ((Int) -> Void)!
+    
+    private let emotionTime: EmotionTime
+    
+    private init(emotionTime: EmotionTime){
         self.emotionTime = emotionTime
-        self.reviewViewModel = viewModel
         super.init(type: .emotionFilter)
     }
     
@@ -23,14 +31,6 @@ class EmotionFilterSheetViewController: BaseSheetViewController {
     }
     
     private let mainView = EmotionFilterSheetView()
-    
-    static func generateFirstEmotionFilter(viewModel: ReviewViewModel) -> EmotionFilterSheetViewController{
-        EmotionFilterSheetViewController(emotionTime: .first, viewModel: viewModel)
-    }
-    
-    static func generateSecondEmotionFilter(viewModel: ReviewViewModel) -> EmotionFilterSheetViewController{
-        EmotionFilterSheetViewController(emotionTime: .second, viewModel: viewModel)
-    }
     
     override func style() {
         super.style()
@@ -87,9 +87,6 @@ extension EmotionFilterSheetViewController: UICollectionViewDelegate, UICollecti
     }
     
     private func selectFilteringEmotion(id: Int){
-        switch emotionTime{
-        case .first:    reviewViewModel.filterFirstEmotion(id: id)
-        case .second:   reviewViewModel.filterSecondEmotion(id: id)
-        }
+        selectedEmotion(id)
     }
 }

--- a/POME/Presentation/ViewControllers/Review/EmotionFilterSheetViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/EmotionFilterSheetViewController.swift
@@ -1,5 +1,5 @@
 //
-//  EmotionFilterSheetTestViewController.swift
+//  EmotionFilterSheetViewController.swift
 //  POME
 //
 //  Created by 박소윤 on 2023/04/05.

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -81,29 +81,6 @@ class ReviewViewController: BaseTabViewController{
                 self?.mainView.tableView.reloadData()
             }).disposed(by: disposeBag)
         
-        
-        var filteringCell: ReviewFilterTableViewCell?{
-            mainView.tableView.cellForRow(at: [INFO_SECTION,2], cellType: ReviewFilterTableViewCell.self)
-        }
-        
-        output.firstEmotionState
-            .drive(onNext: {
-                filteringCell?.firstEmotionFilter.setFilterSelectState(emotion: $0)
-            }).disposed(by: disposeBag)
-        
-        output.secondEmotionState
-            .drive(onNext: {
-                filteringCell?.secondEmotionFilter.setFilterSelectState(emotion: $0)
-            }).disposed(by: disposeBag)
-        
-        output.initializeEmotionFilter
-            .drive(onNext: {
-                filteringCell?.do{
-                    $0.firstEmotionFilter.setFilterDefaultState()
-                    $0.secondEmotionFilter.setFilterDefaultState()
-                }
-            }).disposed(by: disposeBag)
-        
         output.deleteRecord
             .drive(onNext: { indexPath in
                 self.mainView.tableView.deleteRows(at: [indexPath], with: .fade)

--- a/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
+++ b/POME/Presentation/ViewControllers/Review/ReviewViewController.swift
@@ -1,5 +1,5 @@
 //
-//  ReviewTestViewController.swift
+//  ReviewViewController.swift
 //  POME
 //
 //  Created by 박소윤 on 2023/04/03.


### PR DESCRIPTION
## What is this PR? 🔍
회고탭 감정 필터링 리팩토링

## Key Changes 🔑
### 1. 회고탭 감정 필터링 리팩토링
+ 감정 필터링 데이터를 ViewController에 저장하는 것이 아니라, ViewModel에서 저장/관리하는 방식이었습니다. 
+ 추상화가 제대로 되지 않고, 불필요한 메서드 호출 등이 수반되어 ViewController에서 데이터 관리하도록 리팩토링 하였습니다. 
+ UI 바인딩도 리팩토링 하는 과정에서, 프로퍼티 접근 제어를 private으로 변경해 추상화시키는 작업도 진행했습니다. 
### 2. 기존 Test 파일 네이밍에서 Test 제거
+ Test 제거 안된 파일이 있어서 네이밍 변경했습니다. 

## To Reviewers 📢
- 풀 받고 사용해주세요


## Related Issues ⛱
#308